### PR TITLE
Patch to pass threescale info to next filter in the chain

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -176,6 +176,7 @@ mod test {
                     }],
                 }],
             }]),
+            passthrough_metadata: Some(true),
         })
     }
 
@@ -301,7 +302,8 @@ mod test {
                     }
                   ]
                 }
-              ]
+              ],
+              "passthrough_metadata": true
             }"#;
         }
 

--- a/src/configuration/api/v1.rs
+++ b/src/configuration/api/v1.rs
@@ -9,6 +9,8 @@ pub struct Configuration {
     pub system: Option<System>,
     pub backend: Option<Backend>,
     pub services: Option<Vec<Service>>,
+    // pass request to the next filter in the chain
+    pub passthrough_metadata: Option<bool>,
 }
 
 impl Configuration {


### PR DESCRIPTION
This PR adds new configurable behavior to pass threescale's application to the next filter in the chain instead of doing an aurhrep call. Please suggest any edits that you think should be made before merging this PR.