### PR TITLE
rand: introduce a pseudo random number generator for bare targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,6 +272,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+
+[[package]]
+name = "rand_jitter"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a404fd88e0f817fc1c3351b9ba2207ffa65038cdde464405308a5f5d254835fe"
+dependencies = [
+ "libc",
+ "rand_core 0.5.1",
+ "winapi",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_seeder"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612dd698949d531335b4c29d1c64fb11942798decfc08abc218578942e66d7d0"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.3",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -397,6 +465,12 @@ dependencies = [
  "prost",
  "prost-types",
  "proxy-wasm",
+ "rand",
+ "rand_jitter",
+ "rand_pcg",
+ "rand_seeder",
+ "rand_xorshift",
+ "rand_xoshiro",
  "regex",
  "serde",
  "serde_json",
@@ -483,6 +557,28 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xml-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,15 @@ exclude = [
 ]
 
 [features]
-default = ["json_config"]
+default = ["json_config", "prng_pcg32"]
 json_config = []
 # YAML support seems to be buggy within serde_yaml and the unmaintained yaml-rust library - so do not choose unless testing/developing
 yaml_config = ["serde_yaml"]
 # You need to add this one manually to really pick up yaml_config
 danger = []
+prng_pcg32 = ["rand_pcg"]
+prng_xoshiro128 = ["rand_xoshiro"]
+prng_xorshift = ["rand_xorshift"]
 
 [patch.crates-io]
 url = { git = "https://github.com/3scale-rs/rust-url", branch = "3scale" }
@@ -45,6 +48,13 @@ prost = { version = "^0.8", features = ["prost-derive"] }
 prost-types = { version = "^0.8" }
 serde_json = { version = "^1" }
 serde_yaml = { version = "^0.8", optional = true }
+rand = { version = "^0.8", default-features = false }
+rand_seeder = { version = "^0.2" }
+rand_jitter = { version = "^0.3" }
+# PRNG implementation
+rand_xoshiro = { version = "^0.6", optional = true }
+rand_xorshift = { version = "^0.3", optional = true }
+rand_pcg = { version = "^0.3", optional = true }
 
 [dev-dependencies]
 serde_yaml = "^0.8"

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,2 +1,3 @@
 pub mod glob;
+pub mod rand;
 pub mod serde;

--- a/src/util/rand.rs
+++ b/src/util/rand.rs
@@ -1,0 +1,9 @@
+use proxy_wasm::traits::Context;
+
+mod seeding;
+pub use seeding::Error;
+
+pub mod thread_rng;
+pub use thread_rng::{thread_rng_init, thread_rng_init_fallible};
+
+mod prng;

--- a/src/util/rand/prng.rs
+++ b/src/util/rand/prng.rs
@@ -1,0 +1,61 @@
+use rand::{RngCore, SeedableRng};
+
+use super::seeding;
+use super::Context;
+
+#[repr(transparent)]
+pub struct Prng<R: SeedableRng> {
+    rng: R,
+}
+
+impl<R: RngCore + SeedableRng> Prng<R> {
+    pub fn new(ctx: &(dyn Context + Send + Sync), context_id: u32) -> Result<Self, seeding::Error> {
+        Ok(Self {
+            rng: seeding::seed(ctx, context_id)?,
+        })
+    }
+}
+
+impl<R: RngCore + SeedableRng> rand::RngCore for Prng<R> {
+    fn next_u32(&mut self) -> u32 {
+        self.rng.next_u32()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.rng.next_u64()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.rng.fill_bytes(dest)
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+        self.rng.try_fill_bytes(dest)
+    }
+}
+
+#[cfg(not(any(
+    feature = "prng_xorshift",
+    feature = "prng_xoshiro128ss",
+    feature = "prng_pcg32"
+)))]
+compile_error!("at least one PRNG implementation must be chosen via feature flags");
+
+#[cfg(feature = "prng_xoshiro128ss")]
+pub type DefaultPRNG = rand_xoshiro::Xoshiro128StarStar;
+
+#[cfg(all(feature = "prng_pcg32", not(feature = "prng_xoshiro128ss")))]
+pub type DefaultPRNG = rand_pcg::Lcg64Xsh32;
+
+#[cfg(all(
+    feature = "prng_xorshift",
+    not(any(feature = "pcrng_xoshiro128ss", feature = "prng_pcg32"))
+))]
+pub type DefaultPRNG = rand_xorshift::XorShiftRng;
+
+pub fn with_default(
+    ctx: &(dyn Context + Send + Sync),
+    context_id: u32,
+) -> Result<Prng<DefaultPRNG>, seeding::Error> {
+    Prng::<DefaultPRNG>::new(ctx, context_id)
+}

--- a/src/util/rand/seeding.rs
+++ b/src/util/rand/seeding.rs
@@ -1,0 +1,89 @@
+use core::time::Duration;
+use std::time::SystemTime;
+
+use proxy_wasm::traits::Context;
+use rand::SeedableRng;
+use rand_jitter::{rand_core::RngCore, JitterRng};
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Jitter RNG timer is invalid: {0}")]
+    JitterTimer(rand_jitter::TimerError),
+}
+
+fn generate_seed_duration(ctx: &dyn Context) -> Duration {
+    ctx.get_current_time()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_else(|e| {
+            // This can only occur if the current time is earlier than UNIX_EPOCH, iff it's even possible,
+            // but the error returns us the offset, not since but before, UNIX_EPOCH... which is ok for
+            // our purposes anyway.
+            e.duration()
+        })
+}
+
+fn create_jitter_rng<F>(
+    _ctx: &dyn Context,
+    context_id: u32,
+    f: F,
+) -> Result<(rand_jitter::JitterRng<F>, u8), Error>
+where
+    F: Fn() -> u64 + Send + Sync,
+{
+    let mut jrng = JitterRng::new_with_timer(f);
+
+    let rounds = match jrng.test_timer() {
+        Ok(rounds) => rounds,
+        Err(e) => {
+            match e {
+                rand_jitter::TimerError::CoarseTimer => {
+                    log::error!(
+                        "{}: JitterRng: timer source is coarse, seed quality will be reduced",
+                        context_id
+                    );
+                    // maximum suggested number of rounds
+                    128
+                }
+                _ => return Err(Error::JitterTimer(e)),
+            }
+        }
+    };
+
+    jrng.set_rounds(rounds);
+    let _ = jrng.next_u64();
+
+    Ok((jrng, rounds))
+}
+
+fn generate_seed_once(ctx: &(dyn Context + Send + Sync), context_id: u32) -> Result<u128, Error> {
+    let (mut jrng, rounds) = create_jitter_rng(ctx, context_id, || {
+        let ts = generate_seed_duration(ctx);
+
+        // The correct way to calculate the current time is
+        // `ts.as_secs() * 1_000_000_000 + ts.subsec_nanos() as u64`
+        // For a faster version with a very small difference in terms of
+        // entropy (log2(10^9) == 29.9) you can use:
+        // `ts.as_secs() << 30 | ts.subsec_nanos() as u64`
+        ts.as_secs() * 1_000_000_000 + ts.subsec_nanos() as u64
+    })?;
+
+    log::info!(
+        "{}: seed JitterRng configured with {} rounds",
+        context_id,
+        rounds
+    );
+
+    Ok(u128::from(jrng.next_u64()) << 64 | u128::from(jrng.next_u64()))
+}
+
+pub fn seed<R: SeedableRng>(
+    ctx: &(dyn Context + Send + Sync),
+    context_id: u32,
+) -> Result<R, Error> {
+    // hash seed with SipHash
+    use rand_seeder::Seeder;
+
+    let seed = generate_seed_once(ctx, context_id)?;
+    // seed is further hashed and then fed to the chosen RNG
+    Ok(Seeder::from(seed).make_rng())
+}

--- a/src/util/rand/thread_rng.rs
+++ b/src/util/rand/thread_rng.rs
@@ -1,0 +1,141 @@
+use super::prng::with_default;
+use super::prng::DefaultPRNG;
+use super::prng::Prng;
+use super::Context;
+use super::Error;
+
+use rand::RngCore;
+
+// Thread RNG callable from anywhere within the thread.
+// Safe to call this from different contexts as well and
+// obtain ThreadRng instances, since they will all use
+// the same thread local pseudo RNG.
+#[inline]
+#[allow(dead_code)]
+pub fn thread_rng_init_fallible(
+    ctx: &(dyn Context + Send + Sync),
+    context_id: u32,
+) -> Result<ThreadRng, Error> {
+    ThreadRng::thread_rng(ctx, context_id)
+}
+
+// Thread RNG callable from anywhere within the thread.
+// Safe to call this from different contexts as well and
+// obtain ThreadRng instances, since they will all use
+// the same thread local pseudo RNG.
+//
+// Panic: will panic if the thread local RNG could not be initialized.
+#[inline]
+#[allow(dead_code)]
+pub fn thread_rng_init(ctx: &(dyn Context + Send + Sync), context_id: u32) -> ThreadRng {
+    thread_rng_init_fallible(ctx, context_id)
+        .expect("could not initialize thread local random number generator")
+}
+
+// `ThreadRng` is a thread local pseudo random number generator seeded with
+// jitter from the clock source of a proxy-wasm context.
+//
+// The methods in this struct require the user to first initialize the thread
+// local RNG except for the constructor, thread_rng(). Failure to do so will
+// end up in a panic.
+//
+// Note that ThreadRng is a ZST. You can create as many instances as you like,
+// but they all act on the same thread local RNG, so once it is initialized for
+// a given thread you don't need to initialize it anymore.
+#[derive(Debug, Clone, Copy)]
+pub struct ThreadRng;
+
+impl ThreadRng {
+    // Construct a thread
+    #[inline]
+    pub fn thread_rng(
+        ctx: &(dyn Context + Send + Sync),
+        context_id: u32,
+    ) -> Result<Self, super::Error> {
+        imp::initialize(ctx, context_id).and(Ok(Self))
+    }
+
+    // next_u32 without using the RngCore trait which requires a mutable reference
+    #[inline]
+    pub fn u32(&self) -> u32 {
+        imp::next_u32()
+    }
+
+    // next_u64 without using the RngCore trait which requires a mutable reference
+    #[inline]
+    pub fn u64(&self) -> u64 {
+        imp::next_u64()
+    }
+
+    // Use `with` to perform multiple calls in succession to the pseudo RNG.
+    #[inline]
+    pub fn with<R, F: FnOnce(&mut Prng<DefaultPRNG>) -> R>(&self, f: F) -> R {
+        imp::rng_with(f)
+    }
+}
+
+impl RngCore for ThreadRng {
+    fn next_u32(&mut self) -> u32 {
+        self.u32()
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.u64()
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        imp::rng_with(|rng| rng.fill_bytes(dest))
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
+        imp::rng_with(|rng| rng.try_fill_bytes(dest))
+    }
+}
+
+mod imp {
+    use std::cell::RefCell;
+    use std::sync::Once;
+
+    use super::*;
+
+    thread_local! {
+        static RNG: RefCell<Option<Prng<DefaultPRNG>>> = RefCell::new(None);
+        static RNG_INIT: Once = Once::new();
+    }
+
+    pub(super) fn initialize(
+        ctx: &(dyn Context + Send + Sync),
+        context_id: u32,
+    ) -> Result<(), Error> {
+        RNG_INIT.with(|once| {
+            let mut res = Ok(());
+            once.call_once(|| {
+                res = RNG.with(|rng| {
+                    let res_rng = with_default(ctx, context_id);
+                    match res_rng {
+                        Ok(r) => {
+                            let _ = rng.borrow_mut().replace(r);
+                            Ok(())
+                        }
+                        Err(e) => Err(e),
+                    }
+                });
+            });
+            res
+        })
+    }
+
+    #[inline]
+    pub(super) fn next_u32() -> u32 {
+        rng_with(|rng| rng.next_u32())
+    }
+
+    #[inline]
+    pub(super) fn next_u64() -> u64 {
+        rng_with(|rng| rng.next_u64())
+    }
+
+    pub(super) fn rng_with<R, F: FnOnce(&mut Prng<DefaultPRNG>) -> R>(f: F) -> R {
+        RNG.with(|rng| f(rng.borrow_mut().as_mut().unwrap()))
+    }
+}


### PR DESCRIPTION
This is a PRNG meant to be used in a Proxy-WASM filter (but it can
be extracted to receive a timing function) so that we don't need
to go the WASI route to have platform support for RNGs.

With this we'll have a thread-local PRNG that is seeded from the
Proxy-WASM current time function (which in Envoy is currently not
precise enough, so entropy is reduced but still useful) by taking
its jitter (rand_jitter crate) and hashing it (rand_seeder crate)
before using the resulting value as the seed for any one of an
initial choice of pseudo RNGs (PCG32, Xoshiro128**, XorShift).

The implementation relies on a thread-local RefCell which holds
the actual PRNG data, which needs to be initialized at some point.

Initializing the PRNG is not enforced at compile time because there
are limitations in the way we can assign TLS values that would end
up translating the ergonomic issues down the interface (ie. you'd
be unwrapping/checking constantly for something that ideally happens
only once per thread, which is to say only once ever, since this
WASM environment is single-threaded).