### PR TITLE
thread_rng: make next_u{32,64} inherent methods to emulate RngCore by ref

### DIFF
--- a/src/util/rand/thread_rng.rs
+++ b/src/util/rand/thread_rng.rs
@@ -57,13 +57,13 @@ impl ThreadRng {
 
     // next_u32 without using the RngCore trait which requires a mutable reference
     #[inline]
-    pub fn u32(&self) -> u32 {
+    pub fn next_u32(&self) -> u32 {
         imp::next_u32()
     }
 
     // next_u64 without using the RngCore trait which requires a mutable reference
     #[inline]
-    pub fn u64(&self) -> u64 {
+    pub fn next_u64(&self) -> u64 {
         imp::next_u64()
     }
 
@@ -76,11 +76,11 @@ impl ThreadRng {
 
 impl RngCore for ThreadRng {
     fn next_u32(&mut self) -> u32 {
-        self.u32()
+        (&*self).next_u32()
     }
 
     fn next_u64(&mut self) -> u64 {
-        self.u64()
+        (&*self).next_u64()
     }
 
     fn fill_bytes(&mut self, dest: &mut [u8]) {


### PR DESCRIPTION
Turns out I just remembered that whenever Rust sees trait methods
clashing with inherent methods it will always choose the inherent ones
provided the ownership/borrowing is matched.

In our case this change helps us use the next_u32/next_u64 methods as if
the caller was using the RngCore trait, with the important benefit of
just needing a shared reference rather than a mutable one.