### PR TITLE
log: introduce logging module and IdentLogger trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 #![cfg_attr(feature_unsafe_op_in_unsafe_fn, feature(unsafe_op_in_unsafe_fn))]
 
 mod configuration;
+#[macro_use]
+mod log;
 mod proxy;
 mod threescale;
 mod upstream;

--- a/src/proxy/metadata.rs
+++ b/src/proxy/metadata.rs
@@ -1,6 +1,5 @@
 use std::convert::TryFrom;
 
-use log::debug;
 use prost::Message;
 use prost_types::value::Kind as ProtoKind;
 use prost_types::{ListValue as ProtoList, Struct as ProtoStruct, Value as ProtoValue};
@@ -142,7 +141,7 @@ pub trait ValueExt {
     fn as_bool(&self) -> Option<bool>;
     fn match_one<'a>(&'a self, keys: &[&str]) -> Option<&'a Self>;
     fn lookup<'a>(&self, path: &[&'a str]) -> Result<(&Self, &'a str), LookupError> {
-        debug!("looking up path {:?}", path);
+        log::debug!("looking up path {:?}", path);
         path.iter()
             .try_fold((self, "(root)"), |(acc, prev_segment), &segment| {
                 if segment.is_empty() {

--- a/src/proxy/request_headers.rs
+++ b/src/proxy/request_headers.rs
@@ -1,4 +1,3 @@
-use log::debug;
 use proxy_wasm::traits::HttpContext;
 use std::convert::TryFrom;
 use thiserror::Error;
@@ -106,7 +105,7 @@ impl RequestHeaders {
     }
 
     pub fn url(&self) -> Result<Url, anyhow::Error> {
-        debug!("headers: {:?}", self.0);
+        log::debug!("headers: {:?}", self.0);
 
         let scheme = self.get_scheme();
         let authority = self.get(":authority").ok_or(MetadataError::Authority)?;


### PR DESCRIPTION
This module will prefix all logging with a context identifier so we can easily trace logs across contexts _and_ VMs.