### PR TITLE
operations: refactor and add stack and string operations

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -139,11 +139,17 @@ mod test {
                 credentials: Credentials::new(
                     Some(vec![Source::QueryString {
                         keys: vec!["api_key".into()],
-                        ops: Some(vec![Operation::Format(Format::Joined {
-                            separator: ":".into(),
-                            max: Some(2),
-                            indexes: vec![0],
-                        })]),
+                        ops: Some(vec![
+                            Operation::StringOp(StringOp::Split {
+                                separator: ":".into(),
+                                max: Some(2),
+                            }),
+                            Operation::Stack(Stack::Reverse),
+                            Operation::Stack(Stack::Take {
+                                head: None,
+                                tail: Some(1),
+                            }),
+                        ]),
                     }]),
                     Some(vec![
                         Source::Filter {
@@ -228,8 +234,8 @@ mod test {
                           ],
                           "ops": [
                             {
-                              "format": {
-                                "joined": {
+                              "string": {
+                                "split": {
                                   "separator": ":",
                                   "max": 2,
                                   "indexes": [

--- a/src/configuration/operation.rs
+++ b/src/configuration/operation.rs
@@ -1,10 +1,16 @@
+use std::borrow::Cow;
+
 use serde::{Deserialize, Serialize};
 
 mod decode;
 mod format;
+mod stack;
+mod string;
 
 pub use decode::*;
 pub use format::*;
+pub use stack::*;
+pub use string::*;
 
 #[derive(Debug, thiserror::Error)]
 pub enum OperationError {
@@ -12,13 +18,22 @@ pub enum OperationError {
     EncodingError(#[from] DecodeError),
     #[error("format error")]
     FormatError(#[from] FormatError),
+    #[error("input error")]
+    StackError(#[from] StackError),
+    #[error("string op error")]
+    StringOpError(#[from] StringOpError),
+    #[error("operation should have produced at least one value")]
+    NoOutputValue,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Operation {
+    Stack(Stack),
     Decode(Decode),
     Format(Format),
+    #[serde(rename = "string")]
+    StringOp(StringOp),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -26,4 +41,38 @@ pub enum Matcher {
     OneOf(Vec<String>), // produces one result
     Many(Vec<String>),  // produces 1..vec.len() results
     All(Vec<String>),   // produces vec.len() results
+}
+
+pub fn process_operations<'a>(
+    mut v: Vec<Cow<'a, str>>,
+    ops: &[&Operation],
+) -> Result<Vec<Cow<'a, str>>, super::OperationError> {
+    for op in ops {
+        v = match op {
+            Operation::Stack(stack) => stack.process(v)?,
+            Operation::StringOp(string_op) => {
+                let value = v.pop().unwrap();
+                let values = string_op.process(value)?;
+                v.extend(values.into_iter());
+                v
+            }
+            Operation::Decode(decoding) => {
+                let value = v.pop().unwrap();
+                let result = decoding.decode(value)?;
+                v.push(result);
+                v
+            }
+            Operation::Format(format) => {
+                let value = v.pop().unwrap();
+                let values = format.process(value)?;
+                v.extend(values.into_iter());
+                v
+            }
+        };
+        if v.is_empty() {
+            return Err(super::OperationError::NoOutputValue);
+        }
+    }
+
+    Ok(v)
 }

--- a/src/configuration/operation/decode.rs
+++ b/src/configuration/operation/decode.rs
@@ -10,7 +10,7 @@ pub enum DecodeError {
     Utf8Error(#[from] std::string::FromUtf8Error),
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Decode {
     PlainText,

--- a/src/configuration/operation/stack.rs
+++ b/src/configuration/operation/stack.rs
@@ -1,0 +1,252 @@
+use std::borrow::Cow;
+
+use serde::{Deserialize, Serialize};
+
+use super::OperationError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum StackError {
+    #[error("input has no values")]
+    NoValuesError,
+    #[error("output has no values")]
+    OutputNoValuesError,
+    #[error("index out of bounds")]
+    IndexOutOfBounds,
+    #[error("requirement not satisfied")]
+    RequirementNotSatisfied,
+    #[error("inner operation error")]
+    InnerOperationError(#[from] Box<OperationError>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Stack {
+    #[serde(rename = "nop")]
+    NoOp,
+    Length {
+        min: usize,
+        max: usize,
+    },
+    Concat {
+        separator: String,
+    },
+    Reverse,
+    Take {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        head: Option<usize>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        tail: Option<usize>,
+    },
+    Drop {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        head: Option<usize>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        tail: Option<usize>,
+    },
+    Swap {
+        from: isize,
+        to: isize,
+    },
+    Lookup {
+        #[serde(default)]
+        indexes: Vec<isize>,
+    },
+    FlatMap {
+        ops: Vec<super::Operation>,
+    },
+}
+
+impl Default for Stack {
+    fn default() -> Self {
+        Self::NoOp
+    }
+}
+
+impl Stack {
+    pub fn process<'a>(
+        &self,
+        mut input: Vec<Cow<'a, str>>,
+    ) -> Result<Vec<Cow<'a, str>>, StackError> {
+        if input.is_empty() {
+            return Err(StackError::NoValuesError);
+        }
+
+        let res = match self {
+            Self::NoOp => input,
+            Self::Length { min, max } => {
+                if input.len() < *min {
+                    return Err(StackError::RequirementNotSatisfied);
+                }
+                if input.len() > *max {
+                    return Err(StackError::RequirementNotSatisfied);
+                }
+
+                input
+            }
+            Self::Concat { separator } => {
+                let joined = input.join(separator.as_str());
+                vec![joined.into()]
+            }
+            Self::Reverse => {
+                input.reverse();
+                input
+            }
+            Self::Take { head, tail } => {
+                let (mut head_vec, mut tail_vec) = if let Some(head) = head {
+                    let tail = input.split_off(core::cmp::min(*head, input.len()));
+                    (input, tail)
+                } else {
+                    (vec![], input)
+                };
+
+                let tail = if let Some(tail) = tail {
+                    tail_vec.split_off(tail_vec.len().saturating_sub(*tail))
+                } else {
+                    vec![]
+                };
+
+                head_vec.extend(tail.into_iter());
+                head_vec
+            }
+            Self::Drop { head, tail } => {
+                let mut tail_vec = if let Some(head) = head {
+                    let idx = core::cmp::min(*head, input.len());
+                    input.split_off(idx)
+                } else {
+                    input
+                };
+
+                if let Some(tail) = tail {
+                    let _ = tail_vec.split_off(tail_vec.len().saturating_sub(*tail));
+                    tail_vec
+                } else {
+                    tail_vec
+                }
+            }
+            Self::Swap { from, to } => {
+                use self::indexing::{CollectionLength, Index};
+                use core::convert::TryFrom;
+
+                let input_len = CollectionLength::try_from(input.len())?;
+                let from = Index::from(*from);
+                let to = Index::from(*to);
+
+                if from != to {
+                    input.swap(input_len.index_into(from)?, input_len.index_into(to)?);
+                }
+
+                input
+            }
+            Self::Lookup { indexes } => {
+                if indexes.is_empty() {
+                    // take all values
+                    input
+                } else {
+                    use self::indexing::{CollectionLength, Index};
+                    use core::convert::TryFrom;
+
+                    let input_len = CollectionLength::try_from(input.len())?;
+
+                    indexes.iter().try_fold(vec![], |mut acc, &idx| {
+                        input_len.index_into(Index::from(idx)).map(|computed_idx| {
+                            acc.push(Cow::from(input[computed_idx].to_string()));
+                            acc
+                        })
+                    })?
+                }
+            }
+            Self::FlatMap { ops } => {
+                let r = match input.into_iter().try_fold(vec![], |mut acc, e| {
+                    let ops = ops.iter().collect::<Vec<_>>();
+                    super::process_operations(vec![e], ops.as_slice()).map(|v| {
+                        acc.push(v);
+                        acc
+                    })
+                }) {
+                    Ok(r) => r,
+                    Err(e) => return Err(StackError::InnerOperationError(Box::new(e))),
+                };
+                r.into_iter().flatten().collect()
+            }
+        };
+
+        if res.is_empty() {
+            return Err(StackError::OutputNoValuesError);
+        }
+
+        Ok(res)
+    }
+}
+
+mod indexing {
+    use super::StackError;
+
+    #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct Index(isize);
+
+    impl Index {
+        pub fn into_inner(self) -> isize {
+            self.0
+        }
+    }
+
+    impl core::convert::TryFrom<usize> for Index {
+        type Error = StackError;
+
+        fn try_from(value: usize) -> Result<Self, Self::Error> {
+            Ok(Self(
+                isize::try_from(value).map_err(|_| StackError::IndexOutOfBounds)?,
+            ))
+        }
+    }
+
+    impl From<isize> for Index {
+        fn from(value: isize) -> Self {
+            Self(value)
+        }
+    }
+
+    #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct CollectionLength(isize);
+
+    impl CollectionLength {
+        pub fn new(value: isize) -> Result<Self, StackError> {
+            if value < 0 {
+                Err(StackError::IndexOutOfBounds)
+            } else {
+                Ok(Self(value))
+            }
+        }
+
+        // This fn will use Ruby-inspired indexing, ie. -1 meaning last element,
+        // (-collection_len) - 1 meaning as well last element, etc.
+        pub fn index_into(&self, idx: Index) -> Result<usize, StackError> {
+            let idx = idx.into_inner();
+
+            // Safety: `usize` casts are safe - idx as usize is done if idx >= 0,
+            // and `(idx % self.0) as usize` is safe because -n % m is always positive,
+            // since m is always > 0.
+            let computed_idx = if idx >= 0 {
+                idx as usize
+            } else {
+                //let Self(total) = self;
+                (idx % self.0) as usize
+            };
+
+            // Safety: self.0 is checked to be an isize >= 0, so can be casted to usize.
+            if computed_idx >= self.0 as usize {
+                Err(StackError::IndexOutOfBounds)
+            } else {
+                Ok(computed_idx)
+            }
+        }
+    }
+
+    impl core::convert::TryFrom<usize> for CollectionLength {
+        type Error = StackError;
+
+        fn try_from(value: usize) -> Result<Self, Self::Error> {
+            Self::new(isize::try_from(value).map_err(|_| StackError::IndexOutOfBounds)?)
+        }
+    }
+}

--- a/src/configuration/operation/string.rs
+++ b/src/configuration/operation/string.rs
@@ -1,0 +1,98 @@
+use std::borrow::Cow;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, thiserror::Error)]
+pub enum StringOpError {
+    #[error("requirement not satisfied")]
+    RequirementNotSatisfied,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StringOp {
+    #[serde(rename = "nop")]
+    NoOp,
+    Reverse,
+    Split {
+        #[serde(default = "defaults::separator")]
+        separator: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        max: Option<usize>,
+    },
+    Replace {
+        pattern: String,
+        with: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        max: Option<usize>,
+    },
+    Contents {
+        prefix: Option<String>,
+        suffix: Option<String>,
+        contains: Option<String>,
+    },
+}
+
+mod defaults {
+    pub(super) fn separator() -> String {
+        ":".into()
+    }
+}
+
+impl StringOp {
+    pub fn process<'a>(&self, input: Cow<'a, str>) -> Result<Vec<Cow<'a, str>>, StringOpError> {
+        let res = match self {
+            Self::NoOp => vec![input],
+            Self::Reverse => vec![input.chars().into_iter().rev().collect::<String>().into()],
+            Self::Split { separator, max } => {
+                let max = max.unwrap_or(0);
+                if max > 0 {
+                    input
+                        .splitn(max, separator)
+                        .map(|s| Cow::from(s.to_string()))
+                        .collect()
+                } else {
+                    input
+                        .split(separator)
+                        .map(|s| Cow::from(s.to_string()))
+                        .collect()
+                }
+            }
+            Self::Replace { pattern, with, max } => {
+                let max = max.unwrap_or(0);
+                let out = if max > 0 {
+                    input.replacen(pattern, with, max)
+                } else {
+                    input.replace(pattern, with)
+                };
+
+                vec![out.into()]
+            }
+            Self::Contents {
+                prefix,
+                suffix,
+                contains,
+            } => {
+                if let Some(prefix) = prefix {
+                    if !input.starts_with(prefix) {
+                        return Err(StringOpError::RequirementNotSatisfied);
+                    }
+                }
+                if let Some(suffix) = suffix {
+                    if !input.ends_with(suffix) {
+                        return Err(StringOpError::RequirementNotSatisfied);
+                    }
+                }
+                if let Some(substr) = contains {
+                    if !input.contains(substr) {
+                        return Err(StringOpError::RequirementNotSatisfied);
+                    }
+                }
+
+                vec![input]
+            }
+        };
+
+        Ok(res)
+    }
+}

--- a/src/configuration/source.rs
+++ b/src/configuration/source.rs
@@ -136,34 +136,13 @@ impl Source {
         };
 
         res.and_then(|(v, ops)| {
+            let values = vec![v];
             if let Some(ops) = ops {
-                process_encoding_and_format(v, ops).ok()
+                let ops = ops.iter().collect::<Vec<_>>();
+                super::process_operations(values, ops.as_slice()).ok()
             } else {
-                Some(vec![v])
+                Some(values)
             }
         })
     }
-}
-
-fn process_encoding_and_format<'a>(
-    v: Cow<'a, str>,
-    ops: &[Operation],
-) -> Result<Vec<Cow<'a, str>>, super::OperationError> {
-    let mut v = v;
-    for op in ops {
-        v = match op {
-            Operation::Decode(decoding) => decoding.decode(v)?,
-            Operation::Format(format) => {
-                let mut vs = format.parse(v)?;
-                if vs.len() == 1 {
-                    vs.remove(0)
-                } else {
-                    // multiple values... we don't know to which one the next ops (if any) apply
-                    return Ok(vs);
-                }
-            }
-        };
-    }
-
-    Ok(vec![v])
 }


### PR DESCRIPTION
This introduces a series of useful operations to provide for
some flexibility in looking up values and operating on them
to find credentials.

The concept of a stack of values is introduced, with operations
working on single values which will pop the last value and
generate a new one, and operations working on the whole stack,
to reverse values, join them, selecting a few, or ensuring
a certain number of values are present.

String operations are also introduced so you can now reverse
strings, replace substrings, ensure they have a certain length,
and other operations.

In the future we might want to apply some uniformity to these
operations so that we just receive a given input (ie. headers,
query string parameters) and we would apply a pipeline of
lookups and transformations to obtain the values without an
explicit split in between the initial value lookups and the
rest of the operations.