### PR TITLE
lds.yaml: adapt to new op name for splitting strings

### DIFF
--- a/compose/envoy/lds.yaml
+++ b/compose/envoy/lds.yaml
@@ -165,8 +165,8 @@ resources:
                                         ],
                                         "ops": [
                                           {
-                                            "format": {
-                                              "joined": {
+                                            "string": {
+                                              "split": {
                                                 "separator": " ",
                                                 "max": 2,
                                                 "indexes": [1]
@@ -177,8 +177,8 @@ resources:
                                             "decode": "base64_urlsafe"
                                           },
                                           {
-                                            "format": {
-                                              "joined": {
+                                            "string": {
+                                              "split": {
                                                 "separator": ":",
                                                 "max": 2,
                                                 "indexes": [0, 1]
@@ -214,8 +214,8 @@ resources:
                                         ],
                                         "ops": [
                                           {
-                                            "format": {
-                                              "joined": {
+                                            "string": {
+                                              "split": {
                                                 "separator": ":",
                                                 "max": 2,
                                                 "indexes": [


### PR DESCRIPTION
Due to the recent refactor of operations we had some of them change names. This adapts the test environment configuration to use the new names.