### PR TITLE
operation/control: add conditional control primitives

### DIFF
--- a/compose/envoy/lds.yaml
+++ b/compose/envoy/lds.yaml
@@ -112,6 +112,49 @@ resources:
                                       "header": {
                                         "keys": [
                                           "x-app-id"
+                                        ],
+                                        "ops": [
+                                          {
+                                            "control": {
+                                              "assert": {
+                                                "string": "reverse"
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "stack": {
+                                              "log": {
+                                                "id": "prefix-check-before"
+                                              }
+                                            }
+                                          },
+                                          {
+                                            "control": {
+                                              "any": [
+                                                {
+                                                  "string": {
+                                                    "contents": {
+                                                      "prefix": "abc"
+                                                    }
+                                                  }
+                                                },
+                                                {
+                                                  "string": {
+                                                    "contents": {
+                                                      "prefix": "xyz"
+                                                    }
+                                                  }
+                                                }
+                                              ]
+                                            }
+                                          },
+                                          {
+                                            "stack": {
+                                              "log": {
+                                                "id": "prefix-check-after"
+                                              }
+                                            }
+                                          }
                                         ]
                                       }
                                     },

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -140,11 +140,17 @@ mod test {
                     Some(vec![Source::QueryString {
                         keys: vec!["api_key".into()],
                         ops: Some(vec![
+                            Operation::Control(Control::Assert(
+                                Operation::Control(Control::True).into(),
+                            )),
                             Operation::StringOp(StringOp::Split {
                                 separator: ":".into(),
                                 max: Some(2),
                             }),
                             Operation::Stack(Stack::Reverse),
+                            Operation::Stack(Stack::Log {
+                                id: Some("logid".into()),
+                            }),
                             Operation::Stack(Stack::Take {
                                 head: None,
                                 tail: Some(1),

--- a/src/configuration/operation/control.rs
+++ b/src/configuration/operation/control.rs
@@ -1,0 +1,77 @@
+use std::borrow::Cow;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, thiserror::Error)]
+pub enum ControlError {
+    #[error("requirement not satisfied")]
+    RequirementNotSatisfied,
+    #[error("inner operation error")]
+    InnerOperationError(#[from] Box<super::OperationError>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Control {
+    True,
+    False,
+    Any(Vec<super::Operation>),
+    OneOf(Vec<super::Operation>),
+    All(Vec<super::Operation>),
+    None(Vec<super::Operation>),
+    Assert(Box<super::Operation>),
+    Refute(Box<super::Operation>),
+    Log { msg: String },
+}
+
+impl Control {
+    pub fn process<'a>(&self, input: Cow<'a, str>) -> Result<Vec<Cow<'a, str>>, ControlError> {
+        let res = match self {
+            Self::True => vec![input],
+            Self::False => return Err(ControlError::RequirementNotSatisfied),
+            Self::Any(ops) => ops
+                .iter()
+                .find_map(|op| super::process_operations(vec![input.clone()], &[op]).ok())
+                .ok_or(ControlError::RequirementNotSatisfied)?,
+            Self::OneOf(ops) => ops
+                .iter()
+                .try_fold(None, |acc, op| {
+                    if let Ok(result) = super::process_operations(vec![input.clone()], &[op]) {
+                        if acc.is_some() {
+                            None
+                        } else {
+                            Some(Some(result))
+                        }
+                    } else {
+                        Some(acc)
+                    }
+                })
+                .flatten()
+                .ok_or(ControlError::RequirementNotSatisfied)?,
+            Self::All(ops) => ops
+                .iter()
+                .all(|op| super::process_operations(vec![input.clone()], &[op]).is_ok())
+                .then(|| vec![input])
+                .ok_or(ControlError::RequirementNotSatisfied)?,
+            Self::None(ops) => ops
+                .iter()
+                .all(|op| super::process_operations(vec![input.clone()], &[op]).is_err())
+                .then(|| vec![input])
+                .ok_or(ControlError::RequirementNotSatisfied)?,
+            Self::Assert(op) => super::process_operations(vec![input.clone()], &[op])
+                .is_ok()
+                .then(|| vec![input])
+                .ok_or(ControlError::RequirementNotSatisfied)?,
+            Self::Refute(op) => super::process_operations(vec![input.clone()], &[op])
+                .is_err()
+                .then(|| vec![input])
+                .ok_or(ControlError::RequirementNotSatisfied)?,
+            Self::Log { msg } => {
+                log::info!("[3scale-auth]: {}", msg);
+                vec![input]
+            }
+        };
+
+        Ok(res)
+    }
+}

--- a/src/configuration/operation/stack.rs
+++ b/src/configuration/operation/stack.rs
@@ -54,6 +54,10 @@ pub enum Stack {
     FlatMap {
         ops: Vec<super::Operation>,
     },
+    Log {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        id: Option<String>,
+    },
 }
 
 impl Default for Stack {
@@ -167,6 +171,18 @@ impl Stack {
                     Err(e) => return Err(StackError::InnerOperationError(Box::new(e))),
                 };
                 r.into_iter().flatten().collect()
+            }
+            Self::Log { id } => {
+                log::info!(
+                    "[3scale-auth] stack at {}: {}",
+                    id.as_ref().map(|id| id.as_str()).unwrap_or("()"),
+                    input
+                        .iter()
+                        .map(|s| format!(r#""{}""#, s))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                );
+                input
             }
         };
 


### PR DESCRIPTION
This allows just enough control operations to set up conditionals
without introducing loops to the control flow.

These control flow operations always pass the original input to any 
contained operations, but differ on the logic on when the operation
is considered successful as well as on whether the operations are 
mutable or not.

`True` is an always successful operation, whereas `False` is always
unsuccessful.

`Any` is essentially a short-circuit `or` operation, whereas our 
`OneOf` is as short-circuit `xor`. Both operations, when successful,
return the output of the single successful operation.

The rest of the operations just evaluate the operations and drop any 
outputs, returning the input when succesful.

`All` requires that all operations are successful, and if so it returns
the input. Conversely, `None` requires that all operations fail, and if
so it returns the input.

`Assert` just ensures that the operation is successful and passes on its 
input in that case. Conversely, `Refute` passes on the input if the 
operation fails.

`Log` does not change control, but does not seem to merit yet its own 
category. It just outputs a given message.

While at it, this PR also introduces a log stack operation to help debug
issues when writing configurations.