### PR TITLE
operation: make the enum untagged to help lower verbosity

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -240,14 +240,12 @@ mod test {
                           ],
                           "ops": [
                             {
-                              "string": {
-                                "split": {
-                                  "separator": ":",
-                                  "max": 2,
-                                  "indexes": [
-                                    0
-                                  ]
-                                }
+                              "split": {
+                                "separator": ":",
+                                "max": 2,
+                                "indexes": [
+                                  0
+                                ]
                               }
                             }
                           ]
@@ -274,18 +272,14 @@ mod test {
                             "x-jwt-payload"
                           ],
                           "ops": [
+                            "base64_urlsafe",
                             {
-                              "decode": "base64_urlsafe"
-                            },
-                            {
-                              "format": {
-                                "json": {
-                                  "path": [],
-                                  "keys": [
-                                    "azp",
-                                    "aud"
-                                  ]
-                                }
+                              "json": {
+                                "path": [],
+                                "keys": [
+                                  "azp",
+                                  "aud"
+                                ]
                               }
                             }
                           ]

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -148,8 +148,8 @@ mod test {
                                 max: Some(2),
                             }),
                             Operation::Stack(Stack::Reverse),
-                            Operation::Stack(Stack::Log {
-                                id: Some("logid".into()),
+                            Operation::Stack(Stack::Values {
+                                id: Some("stackid".into()),
                             }),
                             Operation::Stack(Stack::Take {
                                 head: None,

--- a/src/configuration/operation.rs
+++ b/src/configuration/operation.rs
@@ -31,7 +31,7 @@ pub enum OperationError {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum Operation {
     Stack(Stack),
     Decode(Decode),

--- a/src/configuration/operation/stack.rs
+++ b/src/configuration/operation/stack.rs
@@ -54,7 +54,7 @@ pub enum Stack {
     FlatMap {
         ops: Vec<super::Operation>,
     },
-    Log {
+    Values {
         #[serde(skip_serializing_if = "Option::is_none")]
         id: Option<String>,
     },
@@ -172,7 +172,7 @@ impl Stack {
                 };
                 r.into_iter().flatten().collect()
             }
-            Self::Log { id } => {
+            Self::Values { id } => {
                 log::info!(
                     "[3scale-auth] stack at {}: {}",
                     id.as_ref().map(|id| id.as_str()).unwrap_or("()"),


### PR DESCRIPTION
This will force serde to parse each potential variant by the operation
name, rather than expecting an operation category first. Clashes are 
possible if variants from different categories have the same name,
although serde will still do a good job of identifying differences
provided they actually exist, otherwise it will break, so this requires
some care to maintain.
