### PR TITLE
operation: clean ups to remove nops, flatten and rename

### DIFF
--- a/src/configuration/operation/decode.rs
+++ b/src/configuration/operation/decode.rs
@@ -13,23 +13,15 @@ pub enum DecodeError {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Decode {
-    PlainText,
     #[serde(rename = "base64_standard")]
     Base64,
     #[serde(rename = "base64_urlsafe")]
     Base64UrlSafe,
 }
 
-impl Default for Decode {
-    fn default() -> Self {
-        Self::PlainText
-    }
-}
-
 impl Decode {
     pub fn decode<'a>(&self, input: Cow<'a, str>) -> Result<Cow<'a, str>, DecodeError> {
         let res = match self {
-            Self::PlainText => input,
             Self::Base64 => Cow::from(String::from_utf8(base64::decode_config(
                 input.as_ref(),
                 base64::STANDARD,

--- a/src/configuration/operation/format.rs
+++ b/src/configuration/operation/format.rs
@@ -16,7 +16,6 @@ pub enum FormatError {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Format {
-    Plain,
     #[serde(rename = "json")]
     Json {
         #[serde(default)]
@@ -31,17 +30,10 @@ pub enum Format {
     },
 }
 
-impl Default for Format {
-    fn default() -> Self {
-        Self::Plain
-    }
-}
-
 impl Format {
     pub fn process<'a>(&self, input: Cow<'a, str>) -> Result<Vec<Cow<'a, str>>, FormatError> {
         use crate::proxy::metadata::ValueExt;
         let res = match self {
-            Self::Plain => vec![input],
             Self::ProtoBuf { path, keys } => {
                 let st = <prost_types::Struct as prost::Message>::decode(input.as_bytes())?;
                 let v = prost_types::Value {

--- a/src/configuration/operation/stack.rs
+++ b/src/configuration/operation/stack.rs
@@ -25,9 +25,7 @@ pub enum Stack {
         min: usize,
         max: usize,
     },
-    Concat {
-        separator: String,
-    },
+    Join(String),
     Reverse,
     Take {
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -78,7 +76,7 @@ impl Stack {
 
                 input
             }
-            Self::Concat { separator } => {
+            Self::Join(separator) => {
                 let joined = input.join(separator.as_str());
                 vec![joined.into()]
             }

--- a/src/configuration/operation/stack.rs
+++ b/src/configuration/operation/stack.rs
@@ -43,13 +43,8 @@ pub enum Stack {
         from: isize,
         to: isize,
     },
-    Lookup {
-        #[serde(default)]
-        indexes: Vec<isize>,
-    },
-    FlatMap {
-        ops: Vec<super::Operation>,
-    },
+    Indexes(#[serde(default)] Vec<isize>),
+    FlatMap(Vec<super::Operation>),
     Values {
         #[serde(skip_serializing_if = "Option::is_none")]
         id: Option<String>,
@@ -130,7 +125,7 @@ impl Stack {
 
                 input
             }
-            Self::Lookup { indexes } => {
+            Self::Indexes(indexes) => {
                 if indexes.is_empty() {
                     // take all values
                     input
@@ -148,7 +143,7 @@ impl Stack {
                     })?
                 }
             }
-            Self::FlatMap { ops } => {
+            Self::FlatMap(ops) => {
                 let r = match input.into_iter().try_fold(vec![], |mut acc, e| {
                     let ops = ops.iter().collect::<Vec<_>>();
                     super::process_operations(vec![e], ops.as_slice()).map(|v| {

--- a/src/configuration/operation/stack.rs
+++ b/src/configuration/operation/stack.rs
@@ -21,8 +21,6 @@ pub enum StackError {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Stack {
-    #[serde(rename = "nop")]
-    NoOp,
     Length {
         min: usize,
         max: usize,
@@ -60,12 +58,6 @@ pub enum Stack {
     },
 }
 
-impl Default for Stack {
-    fn default() -> Self {
-        Self::NoOp
-    }
-}
-
 impl Stack {
     pub fn process<'a>(
         &self,
@@ -76,7 +68,6 @@ impl Stack {
         }
 
         let res = match self {
-            Self::NoOp => input,
             Self::Length { min, max } => {
                 if input.len() < *min {
                     return Err(StackError::RequirementNotSatisfied);

--- a/src/configuration/operation/string.rs
+++ b/src/configuration/operation/string.rs
@@ -11,8 +11,6 @@ pub enum StringOpError {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum StringOp {
-    #[serde(rename = "nop")]
-    NoOp,
     Reverse,
     Split {
         #[serde(default = "defaults::separator")]
@@ -42,7 +40,6 @@ mod defaults {
 impl StringOp {
     pub fn process<'a>(&self, input: Cow<'a, str>) -> Result<Vec<Cow<'a, str>>, StringOpError> {
         let res = match self {
-            Self::NoOp => vec![input],
             Self::Reverse => vec![input.chars().into_iter().rev().collect::<String>().into()],
             Self::Split { separator, max } => {
                 let max = max.unwrap_or(0);


### PR DESCRIPTION
Now that we have flattened the categories, we have several nops that should just be reduced to Control::True, so remove them.

We are also removing object levels from the configuration by making Lookup and FlatMap unit variants, and while at it Lookup has been renamed to Indexes.