### PR TITLE
operation/string: add Glob and GlobSet operations

### DIFF
--- a/src/configuration/operation.rs
+++ b/src/configuration/operation.rs
@@ -30,7 +30,7 @@ pub enum OperationError {
     NoOutputValue,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged, rename_all = "snake_case")]
 pub enum Operation {
     Stack(Stack),

--- a/src/configuration/operation.rs
+++ b/src/configuration/operation.rs
@@ -31,14 +31,14 @@ pub enum OperationError {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged, rename_all = "snake_case")]
+#[serde(untagged)]
 pub enum Operation {
-    Stack(Stack),
-    Decode(Decode),
-    Format(Format),
     #[serde(rename = "string")]
     StringOp(StringOp),
     Control(Control),
+    Decode(Decode),
+    Format(Format),
+    Stack(Stack),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/configuration/operation/control.rs
+++ b/src/configuration/operation/control.rs
@@ -12,7 +12,7 @@ pub enum ControlError {
     InnerOperationError(#[from] Box<super::OperationError>),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Control {
     True,

--- a/src/configuration/operation/decode.rs
+++ b/src/configuration/operation/decode.rs
@@ -10,7 +10,7 @@ pub enum DecodeError {
     Utf8Error(#[from] std::string::FromUtf8Error),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Decode {
     #[serde(rename = "base64_standard")]

--- a/src/configuration/operation/format.rs
+++ b/src/configuration/operation/format.rs
@@ -13,7 +13,7 @@ pub enum FormatError {
     NoStringFound,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Format {
     #[serde(rename = "json")]

--- a/src/configuration/operation/stack.rs
+++ b/src/configuration/operation/stack.rs
@@ -33,7 +33,7 @@ impl Default for CloneMode {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Stack {
     Length {

--- a/src/configuration/operation/string.rs
+++ b/src/configuration/operation/string.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use serde::{Deserialize, Serialize};
 
-use crate::util::glob::GlobPatternSet;
+use crate::util::glob::{GlobPattern, GlobPatternSet};
 
 #[derive(Debug, thiserror::Error)]
 pub enum StringOpError {
@@ -29,6 +29,8 @@ pub enum StringOp {
     Prefix(String),
     Suffix(String),
     Contains(String),
+    GlobSet(GlobPatternSet),
+    Glob(GlobPattern),
 }
 
 mod defaults {
@@ -81,6 +83,20 @@ impl StringOp {
             }
             Self::Contains(contains) => {
                 if !input.contains(contains) {
+                    return Err(StringOpError::RequirementNotSatisfied);
+                }
+
+                vec![input]
+            }
+            Self::Glob(pattern) => {
+                if !pattern.is_match(input.as_ref()) {
+                    return Err(StringOpError::RequirementNotSatisfied);
+                }
+
+                vec![input]
+            }
+            Self::GlobSet(pattern_set) => {
+                if !pattern_set.is_match(input.as_ref()) {
                     return Err(StringOpError::RequirementNotSatisfied);
                 }
 

--- a/src/configuration/operation/string.rs
+++ b/src/configuration/operation/string.rs
@@ -2,13 +2,15 @@ use std::borrow::Cow;
 
 use serde::{Deserialize, Serialize};
 
+use crate::util::glob::GlobPatternSet;
+
 #[derive(Debug, thiserror::Error)]
 pub enum StringOpError {
     #[error("requirement not satisfied")]
     RequirementNotSatisfied,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum StringOp {
     Reverse,

--- a/src/configuration/operation/string.rs
+++ b/src/configuration/operation/string.rs
@@ -24,11 +24,9 @@ pub enum StringOp {
         #[serde(skip_serializing_if = "Option::is_none")]
         max: Option<usize>,
     },
-    Contents {
-        prefix: Option<String>,
-        suffix: Option<String>,
-        contains: Option<String>,
-    },
+    Prefix(String),
+    Suffix(String),
+    Contains(String),
 }
 
 mod defaults {
@@ -65,25 +63,23 @@ impl StringOp {
 
                 vec![out.into()]
             }
-            Self::Contents {
-                prefix,
-                suffix,
-                contains,
-            } => {
-                if let Some(prefix) = prefix {
-                    if !input.starts_with(prefix) {
-                        return Err(StringOpError::RequirementNotSatisfied);
-                    }
+            Self::Prefix(prefix) => {
+                if !input.starts_with(prefix) {
+                    return Err(StringOpError::RequirementNotSatisfied);
                 }
-                if let Some(suffix) = suffix {
-                    if !input.ends_with(suffix) {
-                        return Err(StringOpError::RequirementNotSatisfied);
-                    }
+
+                vec![input]
+            }
+            Self::Suffix(suffix) => {
+                if !input.ends_with(suffix) {
+                    return Err(StringOpError::RequirementNotSatisfied);
                 }
-                if let Some(substr) = contains {
-                    if !input.contains(substr) {
-                        return Err(StringOpError::RequirementNotSatisfied);
-                    }
+
+                vec![input]
+            }
+            Self::Contains(contains) => {
+                if !input.contains(contains) {
+                    return Err(StringOpError::RequirementNotSatisfied);
                 }
 
                 vec![input]

--- a/src/util/glob.rs
+++ b/src/util/glob.rs
@@ -22,11 +22,21 @@ pub enum Error {
 #[serde(try_from = "String", into = "String")]
 pub struct GlobPattern(Regex);
 
+impl<'a> TryFrom<&'a str> for GlobPattern {
+    type Error = Error;
+
+    #[inline]
+    fn try_from(s: &'a str) -> Result<Self, Self::Error> {
+        Self::new(s)
+    }
+}
+
 impl TryFrom<String> for GlobPattern {
     type Error = Error;
 
-    fn try_from(s: String) -> Result<Self, Self::Error> {
-        Self::new(s.as_str())
+    #[inline]
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::try_from(value.as_str())
     }
 }
 
@@ -129,6 +139,14 @@ impl TryFrom<Vec<String>> for GlobPatternSet {
 
     fn try_from(v: Vec<String>) -> Result<Self, Self::Error> {
         Self::new(v.iter().map(|pat| GlobPattern::glob_pattern(pat.as_str())))
+    }
+}
+
+impl<'a> TryFrom<&'a str> for GlobPatternSet {
+    type Error = Error;
+
+    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+        Self::new(core::iter::once(GlobPattern::glob_pattern(value)))
     }
 }
 


### PR DESCRIPTION
This allows for more efficient, glob based tests, and refactors the Contains operation into its three sub-operations: Prefix, Suffix and Contains.

While at it also reorder the Operation enum so that serde's untagged feature looks up first the most common operations.