### PR TITLE
operation: make process_operations generic over ops being owned or ref

### DIFF
--- a/src/configuration/operation.rs
+++ b/src/configuration/operation.rs
@@ -41,6 +41,12 @@ pub enum Operation {
     Stack(Stack),
 }
 
+impl AsRef<Operation> for Operation {
+    fn as_ref(&self) -> &Operation {
+        self
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Matcher {
     OneOf(Vec<String>), // produces one result
@@ -48,12 +54,12 @@ pub enum Matcher {
     All(Vec<String>),   // produces vec.len() results
 }
 
-pub fn process_operations<'a>(
+pub fn process_operations<'a, O: AsRef<Operation>>(
     mut v: Vec<Cow<'a, str>>,
-    ops: &[&Operation],
+    ops: &[O],
 ) -> Result<Vec<Cow<'a, str>>, super::OperationError> {
     for op in ops {
-        v = match op {
+        v = match op.as_ref() {
             Operation::Stack(stack) => stack.process(v)?,
             Operation::Control(control) => control.process(v)?,
             Operation::StringOp(string_op) => string_op.process(v)?,

--- a/src/configuration/operation/stack.rs
+++ b/src/configuration/operation/stack.rs
@@ -168,7 +168,6 @@ impl Stack {
             }
             Self::FlatMap(ops) => {
                 let r = match stack.into_iter().try_fold(vec![], |mut acc, e| {
-                    let ops = ops.iter().collect::<Vec<_>>();
                     super::process_operations(vec![e], ops.as_slice()).map(|v| {
                         acc.push(v);
                         acc
@@ -181,15 +180,11 @@ impl Stack {
             }
             Self::Select(ops) => stack
                 .into_iter()
-                .filter_map(|e| {
-                    let ops = ops.iter().collect::<Vec<_>>();
-                    super::process_operations(vec![e], ops.as_slice()).ok()
-                })
+                .filter_map(|e| super::process_operations(vec![e], ops.as_slice()).ok())
                 .flatten()
                 .collect::<Vec<_>>(),
             Self::Cloned { result, ops } => {
                 let new_stack = stack.clone();
-                let ops = ops.iter().collect::<Vec<_>>();
                 match super::process_operations(new_stack, ops.as_slice()) {
                     Ok(mut v) => match result {
                         CloneMode::AppendResult => {

--- a/src/configuration/source.rs
+++ b/src/configuration/source.rs
@@ -160,7 +160,6 @@ impl Source {
 
         res.and_then(|(values, ops)| {
             if let Some(ops) = ops {
-                let ops = ops.iter().collect::<Vec<_>>();
                 super::process_operations(values, ops.as_slice()).ok()
             } else {
                 Some(values)


### PR DESCRIPTION
This avoids a few vec allocations in exchange of a couple
monomorphizations for process_operations.