### PR TITLE
Fix op clashes and add string len, bytelen and rsplit

### DIFF
--- a/src/configuration/operation/stack.rs
+++ b/src/configuration/operation/stack.rs
@@ -36,9 +36,12 @@ impl Default for CloneMode {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Stack {
+    #[serde(rename = "stack_len")]
     Length {
-        min: usize,
-        max: usize,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        min: Option<usize>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        max: Option<usize>,
     },
     Join(String),
     #[serde(rename = "stack_rev")]
@@ -86,11 +89,15 @@ impl Stack {
 
         let res = match self {
             Self::Length { min, max } => {
-                if stack.len() < *min {
-                    return Err(StackError::RequirementNotSatisfied);
+                if let Some(min) = min {
+                    if stack.len() < *min {
+                        return Err(StackError::RequirementNotSatisfied);
+                    }
                 }
-                if stack.len() > *max {
-                    return Err(StackError::RequirementNotSatisfied);
+                if let Some(max) = max {
+                    if stack.len() > *max {
+                        return Err(StackError::RequirementNotSatisfied);
+                    }
                 }
 
                 stack

--- a/src/configuration/operation/stack.rs
+++ b/src/configuration/operation/stack.rs
@@ -41,6 +41,7 @@ pub enum Stack {
         max: usize,
     },
     Join(String),
+    #[serde(rename = "stack_rev")]
     Reverse,
     Take {
         #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
This fixes issues with disambiguating a few stack operations with the strings homonyms, and adds string length operations (in UTF8 and u8 modes) as well as a reverse split operation.