### PR TITLE
operations: refactor op names and functionality

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -140,9 +140,9 @@ mod test {
                     Some(vec![Source::QueryString {
                         keys: vec!["api_key".into()],
                         ops: Some(vec![
-                            Operation::Control(Control::Assert(
-                                Operation::Control(Control::True).into(),
-                            )),
+                            Operation::Control(Control::Assert(vec![Operation::Control(
+                                Control::True,
+                            )])),
                             Operation::StringOp(StringOp::Split {
                                 separator: ":".into(),
                                 max: Some(2),

--- a/src/configuration/operation/control.rs
+++ b/src/configuration/operation/control.rs
@@ -14,6 +14,19 @@ pub enum ControlError {
     InnerOperationError(#[from] Box<super::OperationError>),
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StackExtendMode {
+    Prepend,
+    Append,
+}
+
+impl Default for StackExtendMode {
+    fn default() -> Self {
+        Self::Append
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Control {
@@ -23,8 +36,22 @@ pub enum Control {
     OneOf(Vec<super::Operation>),
     All(Vec<super::Operation>),
     None(Vec<super::Operation>),
-    Assert(Box<super::Operation>),
-    Refute(Box<super::Operation>),
+    Assert(Vec<super::Operation>),
+    Refute(Vec<super::Operation>),
+    Group(Vec<super::Operation>),
+    Cloned {
+        #[serde(default)]
+        result: StackExtendMode,
+        ops: Vec<super::Operation>,
+    },
+    Partial {
+        #[serde(default)]
+        result: StackExtendMode,
+        ops: Vec<super::Operation>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        max: Option<usize>,
+    },
+    Pipe(Vec<super::Operation>),
     Log {
         #[serde(default)]
         level: LogLevel,
@@ -91,20 +118,73 @@ impl Control {
                     stack
                 })
                 .ok_or(ControlError::RequirementNotSatisfied)?,
-            Self::Assert(op) => super::process_operations(vec![input.clone()], &[op])
-                .is_ok()
-                .then(|| {
-                    stack.push(input);
-                    stack
-                })
-                .ok_or(ControlError::RequirementNotSatisfied)?,
-            Self::Refute(op) => super::process_operations(vec![input.clone()], &[op])
-                .is_err()
-                .then(|| {
-                    stack.push(input);
-                    stack
-                })
-                .ok_or(ControlError::RequirementNotSatisfied)?,
+            Self::Assert(ops) => {
+                stack.push(input);
+
+                let _ = super::process_operations(stack.clone(), ops)
+                    .map_err(|_| ControlError::RequirementNotSatisfied)?;
+
+                stack
+            }
+            Self::Refute(ops) => {
+                stack.push(input);
+
+                if super::process_operations(stack.clone(), ops).is_ok() {
+                    return Err(ControlError::RequirementNotSatisfied);
+                }
+
+                stack
+            }
+            Self::Group(ops) => {
+                stack.push(input);
+                super::process_operations(stack, ops.as_slice())
+                    .map_err(|e| ControlError::InnerOperationError(e.into()))?
+            }
+            Self::Cloned { result, ops } => {
+                let new_stack = stack.clone();
+                match super::process_operations(new_stack, ops.as_slice()) {
+                    Ok(mut v) => match result {
+                        StackExtendMode::Append => {
+                            stack.extend(v.into_iter());
+                            stack
+                        }
+                        StackExtendMode::Prepend => {
+                            v.extend(stack.into_iter());
+                            v
+                        }
+                    },
+                    Err(e) => return Err(ControlError::InnerOperationError(Box::new(e))),
+                }
+            }
+            Self::Partial { result, ops, max } => {
+                let max = core::cmp::min(max.unwrap_or(1), 1);
+                let partial = stack.split_off(stack.len().saturating_sub(max));
+                if partial.is_empty() {
+                    return Err(ControlError::NoValuesError);
+                }
+
+                match super::process_operations(partial, ops.as_slice()) {
+                    Ok(mut v) => match result {
+                        StackExtendMode::Append => {
+                            stack.extend(v.into_iter());
+                            stack
+                        }
+                        StackExtendMode::Prepend => {
+                            v.extend(stack.into_iter());
+                            v
+                        }
+                    },
+                    Err(e) => return Err(ControlError::InnerOperationError(Box::new(e))),
+                }
+            }
+            Self::Pipe(ops) => {
+                stack.extend(
+                    super::process_operations(vec![input], ops.as_slice())
+                        .map_err(|_| ControlError::RequirementNotSatisfied)?
+                        .into_iter(),
+                );
+                stack
+            }
             Self::Log { level, msg } => {
                 crate::log!(&"[3scale-auth/config]", *level, "{}", msg);
                 stack.push(input);

--- a/src/configuration/operation/stack.rs
+++ b/src/configuration/operation/stack.rs
@@ -30,6 +30,7 @@ pub enum Stack {
     },
     Join(String),
     Reverse,
+    Contains(String),
     Take {
         #[serde(skip_serializing_if = "Option::is_none")]
         head: Option<usize>,
@@ -87,6 +88,12 @@ impl Stack {
             }
             Self::Reverse => {
                 stack.reverse();
+                stack
+            }
+            Self::Contains(value) => {
+                if !stack.contains(&value.into()) {
+                    return Err(StackError::RequirementNotSatisfied);
+                }
                 stack
             }
             Self::Take { head, tail } => {

--- a/src/configuration/operation/stack.rs
+++ b/src/configuration/operation/stack.rs
@@ -22,7 +22,6 @@ pub enum StackError {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum Stack {
-    #[serde(rename = "stack_len")]
     Length {
         #[serde(skip_serializing_if = "Option::is_none")]
         min: Option<usize>,
@@ -30,7 +29,6 @@ pub enum Stack {
         max: Option<usize>,
     },
     Join(String),
-    #[serde(rename = "stack_rev")]
     Reverse,
     Take {
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/configuration/operation/string.rs
+++ b/src/configuration/operation/string.rs
@@ -39,7 +39,7 @@ impl LengthMode {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum StringOp {
-    #[serde(rename = "len")]
+    #[serde(rename = "strlen")]
     Length {
         #[serde(skip_serializing_if = "Option::is_none")]
         min: Option<usize>,
@@ -48,6 +48,7 @@ pub enum StringOp {
         #[serde(default)]
         mode: LengthMode,
     },
+    #[serde(rename = "strrev")]
     Reverse,
     Split {
         #[serde(default = "defaults::separator")]

--- a/src/configuration/operation/string.rs
+++ b/src/configuration/operation/string.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use serde::{Deserialize, Serialize};
 
-use crate::util::glob::{GlobPattern, GlobPatternSet};
+use crate::util::glob::GlobPatternSet;
 
 #[derive(Debug, thiserror::Error)]
 pub enum StringOpError {
@@ -71,9 +71,9 @@ pub enum StringOp {
     },
     Prefix(String),
     Suffix(String),
-    Contains(String),
-    GlobSet(GlobPatternSet),
-    Glob(GlobPattern),
+    #[serde(rename = "substr")]
+    SubString(String),
+    Glob(GlobPatternSet),
 }
 
 mod defaults {
@@ -154,21 +154,14 @@ impl StringOp {
 
                 stack.push(input);
             }
-            Self::Contains(contains) => {
+            Self::SubString(contains) => {
                 if !input.contains(contains) {
                     return Err(StringOpError::RequirementNotSatisfied);
                 }
 
                 stack.push(input);
             }
-            Self::Glob(pattern) => {
-                if !pattern.is_match(input.as_ref()) {
-                    return Err(StringOpError::RequirementNotSatisfied);
-                }
-
-                stack.push(input);
-            }
-            Self::GlobSet(pattern_set) => {
+            Self::Glob(pattern_set) => {
                 if !pattern_set.is_match(input.as_ref()) {
                     return Err(StringOpError::RequirementNotSatisfied);
                 }


### PR DESCRIPTION
This includes a few changes in:

- Ops that are renamed because stack are more prevalent than string-based, as well as a bit of reorganization into different categories.
- Assert/Refute now accept multiple ops, and have no side effects.
- Partial presents a new stack made up of any number of elements in the tail and then merges them with the remaining part of the stack, protecting the remaining elements - like Clone without actually cloning and only taking elements from the tail.