### PR TITLE
Add a Test operation to evaluate conditionals

### DIFF
--- a/src/configuration/operation/control.rs
+++ b/src/configuration/operation/control.rs
@@ -153,7 +153,7 @@ impl Control {
                             v
                         }
                     },
-                    Err(e) => return Err(ControlError::InnerOperationError(Box::new(e))),
+                    Err(e) => return Err(ControlError::InnerOperationError(e.into())),
                 }
             }
             Self::Partial { result, ops, max } => {
@@ -174,7 +174,7 @@ impl Control {
                             v
                         }
                     },
-                    Err(e) => return Err(ControlError::InnerOperationError(Box::new(e))),
+                    Err(e) => return Err(ControlError::InnerOperationError(e.into())),
                 }
             }
             Self::Pipe(ops) => {

--- a/src/configuration/operation/control.rs
+++ b/src/configuration/operation/control.rs
@@ -32,6 +32,13 @@ impl Default for StackExtendMode {
 pub enum Control {
     True,
     False,
+    Test {
+        #[serde(rename = "if")]
+        r#if: Box<super::Operation>,
+        then: Vec<super::Operation>,
+        #[serde(rename = "else", default)]
+        r#else: Vec<super::Operation>,
+    },
     Any(Vec<super::Operation>),
     OneOf(Vec<super::Operation>),
     All(Vec<super::Operation>),
@@ -80,6 +87,16 @@ impl Control {
                         .into_iter(),
                 );
                 stack
+            }
+            Self::Test { r#if, then, r#else } => {
+                let ops = if super::process_operations(stack.clone(), &[r#if]).is_ok() {
+                    then
+                } else {
+                    r#else
+                };
+
+                super::process_operations(stack, ops.as_slice())
+                    .map_err(|e| ControlError::InnerOperationError(e.into()))?
             }
             Self::OneOf(ops) => {
                 stack.extend(


### PR DESCRIPTION
This allows users to specify a condition and a `then` branch, optionally with an `else` branch. A `then` with no `else` will succeed if either the condition fails or the condition succeeds _and_ the operations in `then` succeed as well.