### PR TITLE
upstream: accept custom query strings when calling out

### DIFF
--- a/src/proxy/http_context.rs
+++ b/src/proxy/http_context.rs
@@ -97,6 +97,7 @@ impl HttpContext for HttpAuthThreescale {
                 uri.as_ref(),
                 request.method.as_str(),
                 headers,
+                None,
                 body.map(str::as_bytes),
                 None,
                 None,


### PR DESCRIPTION
This accepts setting extra query strings when calling out to an upstream.