### PR TITLE
Enable builiding via a builder container

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ To run the demo:
 
 1. Edit lds.conf in compose/envoy to fill in service data (ids, tokens, rules, ...).
 2. Optionally edit compose/envoy/envoy.yaml to point the 3scale SaaS cluster to your 3scale (backend) instance.
-3. Run `make build` to build the WebAssembly extension.
-4. Run `make up` to run the docker-compose environment.
+3. Run `make build-with-container` to build the WebAssembly extension.
+4. Run `make up` to run the `docker-compose` environment.
 5. Run `make shell` in a different terminal and explore the scripts in `/examples`.
    There is an OIDC script that obtains a token from Keycloak and uses it to authenticate against the proxy.
 

--- a/ci/Dockerfile.build
+++ b/ci/Dockerfile.build
@@ -1,0 +1,21 @@
+FROM docker.io/library/rust:1.54.0-bullseye
+
+ARG WASM_SNIP_VERSION_SPEC="^0.4"
+ARG WASM_GC_VERSION_SPEC="^0.1"
+
+RUN rustup target install wasm32-unknown-unknown \
+ && cargo install --version "${WASM_SNIP_VERSION_SPEC}" wasm-snip \
+ && cargo install --version "${WASM_GC_VERSION_SPEC}" wasm-gc \
+ && cargo new --lib /fetcher
+
+COPY Cargo.toml Cargo.lock /
+
+RUN mv /Cargo.* /fetcher \
+ && cd /fetcher \
+ && cargo fetch \
+ && cd / \
+ && rm -rf /fetcher
+
+WORKDIR /build
+
+CMD ["make", "build"]


### PR DESCRIPTION
This avoids the need to have Rust with the WASM targets installed and
the tooling to strip the binary blob.