### PR TITLE
Improve examples and use info as default loglevel

### DIFF
--- a/compose/docker-compose.yaml
+++ b/compose/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "2.2"
 services:
   ingress:
     image: istio/proxyv2:1.9.8
-    entrypoint: /bin/bash -c 'sleep 1 && /usr/local/bin/envoy -c /etc/envoy/envoy.yaml --bootstrap-version 3 --service-cluster $$(domainname) --service-node $$(hostname) --log-level trace'
+    entrypoint: /bin/bash -c 'sleep 1 && /usr/local/bin/envoy -c /etc/envoy/envoy.yaml --bootstrap-version 3 --service-cluster $$(domainname) --service-node $$(hostname) --log-level ${LOG_LEVEL:-info}'
     volumes:
       - ${ENVOY_DIR:-./envoy}:/etc/envoy/:z,rw
       - ${WASM_FILTER:-./wasm}:/etc/proxy-wasm/:z,rw

--- a/compose/envoy/lds.yaml
+++ b/compose/envoy/lds.yaml
@@ -39,6 +39,8 @@ resources:
                         audiences:
                           - admin-cli
                           - test
+                          - mobile-app
+                          - another-app
                         remote_jwks:
                           http_uri:
                             uri: https://keycloak:8443/auth/realms/master/protocol/openid-connect/certs

--- a/compose/examples/basic_auth_app_id_with_key.sh
+++ b/compose/examples/basic_auth_app_id_with_key.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-curl -v -u 123:456 -X GET "http://ingress/oxc"

--- a/compose/examples/oidc.sh
+++ b/compose/examples/oidc.sh
@@ -144,13 +144,21 @@ get_client_secret() {
 }
 
 main() {
-	local web="${1}"
-	local url="${2}"
-	local realm="${3}"
-	local client_id="${4}"
+	local client_id="${1}"
+	local web="${2}"
+	local url="${3}"
+	local realm="${4}"
 	local user="${5:-${KEYCLOAK_USER:-admin}}"
 	local passwd="${6:-${KEYCLOAK_PASSWORD:-admin}}"
 
+	echo >&2 "Note optional args: <client_id> <proxy-url> <idp-url> <realm> <user> <passwd>"
+
+	if test "x${client_id}" = "x"; then
+		echo >&2 "No client id specified, taking default test"
+		client_id="test"
+	else
+		echo >&2 "Please ensure ${client_id} is specified in the allow list of audiences"
+	fi
 	if test "x${web}" = "x"; then
 		echo >&2 "No proxy URL specified, taking default http://ingress/oidc"
 		web="http://ingress/oidc"
@@ -162,10 +170,6 @@ main() {
 	if test "x${realm}" = "x"; then
 		echo >&2 "No realm specified, taking default master"
 		realm="master"
-	fi
-	if test "x${client_id}" = "x"; then
-		echo >&2 "No client id specified, taking default test"
-		client_id="test"
 	fi
 
 	rm -f /tmp/cookies

--- a/compose/examples/oidc_external.sh
+++ b/compose/examples/oidc_external.sh
@@ -144,13 +144,23 @@ get_client_secret() {
 }
 
 main() {
-	local web="${1}"
-	local url="${2}"
-	local realm="${3}"
-	local client_id="${4}"
+	local client_id="${1}"
+	local web="${2}"
+	local url="${3}"
+	local realm="${4}"
 	local user="${5:-${KEYCLOAK_USER:-admin}}"
 	local passwd="${6:-${KEYCLOAK_PASSWORD:-admin}}"
 
+	echo >&2 "Note optional args: <client_id> <proxy-url> <idp-url> <realm> <use
+r> <passwd>"
+
+	if test "x${client_id}" = "x"; then
+		echo >&2 "No client id specified, taking default test"
+		client_id="test"
+	else
+		echo >&2 "Please ensure ${client_id} is specified in the allow list of audiences"
+
+	fi
 	if test "x${web}" = "x"; then
 		echo >&2 "No proxy URL specified, taking default http://ingress/oidc"
 		web="http://ingress/oidc"
@@ -162,10 +172,6 @@ main() {
 	if test "x${realm}" = "x"; then
 		echo >&2 "No realm specified, taking default master"
 		realm="master"
-	fi
-	if test "x${client_id}" = "x"; then
-		echo >&2 "No client id specified, taking default test"
-		client_id="test"
 	fi
 
 	rm -f ./cookies

--- a/compose/examples/open_sesame.sh
+++ b/compose/examples/open_sesame.sh
@@ -1,4 +1,24 @@
 #!/bin/sh
 
-BASE64="${BASE64:-YWxhZGRpbjpvcGVuc2VzYW1l}"
-curl -vvv -H "Authorization: Basic ${BASE64}" "http://ingress/lala"
+PLAINTEXT="${1:-"aladdin:opensesame"}"
+
+base64_urlencode()
+{
+  echo -n "${1}" | base64 | tr '/+' '_-' | tr -d '='
+}
+
+main()
+{
+  local plaintext="${1:-"aladdin:opensesame"}"
+  local proxy_url="${2:-"http://ingress/somepath"}"
+  local encoded="${BASE64}"
+
+  if test "x${BASE64}" = "x"; then
+    encoded=$(base64_urlencode "${plaintext}")
+    echo "Base64url'ed: ${encoded}"
+  fi
+
+  curl -vvv -H "Authorization: Basic ${encoded}" "${proxy_url}"
+}
+
+main "${@}"

--- a/compose/examples/query_string_app_id_key.sh
+++ b/compose/examples/query_string_app_id_key.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+curl -v -X GET "http://ingress/some_path?param=1&app_id=some_app_id&other_param=3&app_key=some_app_key"

--- a/compose/examples/user_key.sh
+++ b/compose/examples/user_key.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+curl -v -X GET "http://ingress/some_path?param=1&api_key=some_api_key&other_param=3"

--- a/src/upstream.rs
+++ b/src/upstream.rs
@@ -91,7 +91,7 @@ impl Upstream {
             Some(bytes) => String::from_utf8_lossy(bytes),
             None => "(nothing)".into(),
         };
-        log::debug!(
+        log::info!(
             "calling out {} (using {} scheme) with headers -> {:?} <- and body -> {:?} <-",
             name,
             scheme,


### PR DESCRIPTION
The examples have been reworked to accept a client_id in the OIDC ones or a Basic Auth string plaintext in the `open_sesame` one.