### PR TITLE
util/rand/thread_rng: allow clippy lint for self named constructor

### DIFF
--- a/src/util/rand/thread_rng.rs
+++ b/src/util/rand/thread_rng.rs
@@ -47,6 +47,7 @@ pub struct ThreadRng;
 
 impl ThreadRng {
     // Construct a thread
+    #[allow(clippy::self_named_constructors)]
     #[inline]
     pub fn thread_rng(
         ctx: &(dyn Context + Send + Sync),


### PR DESCRIPTION
This is a new lint in 1.55, which arguably makes sense but we would be breaking quite a bit of code if we came up with a different name now, so let's just allow the lint in this case.