### PR TITLE
docker-compose: clean up keycloak entry and stop adding a config volume

### DIFF
--- a/compose/docker-compose.yaml
+++ b/compose/docker-compose.yaml
@@ -39,12 +39,9 @@ services:
     logging:
       driver: none
     image: quay.io/keycloak/keycloak:12.0.4
-    volumes:
-      - ${KEYCLOAK_DIR:-./keycloak}:/etc/keycloak/:z,ro
     environment:
       KEYCLOAK_USER: admin
       KEYCLOAK_PASSWORD: admin
-      #KEYCLOAK_IMPORT: /etc/keycloak/import.json -Dkeycloak.profile.feature.upload_scripts=enabled
       PROXY_ADDRESS_FORWARDING: "true"
     expose:
       - "8080"


### PR DESCRIPTION
This is not being used and causes an issue when building the module via
a container because it creates an empty, root-owned directory in the
compose folder that crashes the actual build process because of the
ownership.

We are not using it anyway, so let's just remove it.