### PR TITLE
Add early warning test for upcoming breaking clippy in beta & update MSRV to 1.54

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
           - stable
           - beta
             # MSRV
-          - 1.52.1
+          - 1.54.0
         experimental: [false]
         cargo_flags: [--all-features]
         include:

--- a/.github/workflows/clippy.yaml
+++ b/.github/workflows/clippy.yaml
@@ -11,6 +11,15 @@ on:
 jobs:
   clippy_check:
     runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        rust:
+          - stable
+          # Help identify breakages about to land in stable earlier
+          - beta
+
     steps:
       - uses: actions/checkout@v2
         with:

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,5 @@
-status = ["ci (stable, false, --all-features)", "ci (beta, false, --all-features)", "ci (1.52.1, false, --all-features)", "clippy_check", "rustfmt", "audit_check", "licensing (bans licenses sources)"]
-pr_status = ["ci (stable, false, --all-features)", "ci (beta, false, --all-features)", "ci (1.52.1, false, --all-features)", "clippy_check", "rustfmt", "audit_check", "licensing (bans licenses sources)"]
+status = ["ci (stable, false, --all-features)", "ci (beta, false, --all-features)", "ci (1.54.0, false, --all-features)", "clippy_check (stable)", "rustfmt", "audit_check", "licensing (bans licenses sources)"]
+pr_status = ["ci (stable, false, --all-features)", "ci (beta, false, --all-features)", "ci (1.54.0, false, --all-features)", "clippy_check (stable)", "rustfmt", "audit_check", "licensing (bans licenses sources)"]
 timeout_sec = 1800
 use_squash_merge = false
 block_labels = ["wip"]


### PR DESCRIPTION
This week we've had a new stable clippy lint in the 1.55.0 release that broke our CI. Let's have early warnings about upcoming breakages like that in clippy about to land in stable by also having information about the beta channel's clippy.

Also: test MSRV with 1.54.0.