### PR TITLE
Add environment to service config

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -351,6 +351,7 @@ to do useful work.
 services:
   - id: "2555417834789"
     token: service_token
+    environment: production
     authorities:
       - "*.app"
       - 0.0.0.0
@@ -364,6 +365,7 @@ Each element in the `services` array represents a `3scale` service. The fields a
 * `id`: Required. The `3scale` service identifier for this service.
 * `token`: Required. The `3scale` service token to be used to authenticate this service against
            Apisonator.
+* `environment`: Optional, defaults to `production`. The `3scale` environment of this service.
 * `authorities`: Required. An array of strings, each one representing the [`Authority`](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#Syntax)
                  of a `URL` to match. These strings do accept [`glob patterns`](https://en.wikipedia.org/wiki/Glob_%28programming%29)
                  supporting the `*`, `+` and `?` matchers.

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -73,7 +73,9 @@ mod test {
 
     use threescalers::http::mapping_rule::{Method, RestRule};
 
-    use crate::threescale::{Backend, Credentials, MappingRule, Service, System, Usage};
+    use crate::threescale::{
+        Backend, Credentials, Environment, MappingRule, Service, System, Usage,
+    };
     use crate::upstream::Upstream;
     use crate::util::glob::GlobPatternSet;
     use crate::util::serde::ErrorLocation;
@@ -125,6 +127,7 @@ mod test {
             services: Some(vec![Service {
                 id: "2555417834780".into(),
                 token: "service_token".into(),
+                environment: Environment::Production,
                 authorities: GlobPatternSet::new(
                     [
                         "ingress",

--- a/src/threescale.rs
+++ b/src/threescale.rs
@@ -8,6 +8,6 @@ mod usage;
 pub use backend::Backend;
 pub use credentials::{Credentials, Error as CredentialsError};
 pub use mapping_rule::MappingRule;
-pub use service::Service;
+pub use service::{Environment, Service};
 pub use system::System;
 pub use usage::Usage;

--- a/src/threescale/service.rs
+++ b/src/threescale/service.rs
@@ -4,8 +4,37 @@ use super::{Credentials, MappingRule};
 use crate::util::glob::GlobPatternSet;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Environment {
+    Production,
+    Staging,
+    Sandbox,
+    #[serde(other)]
+    Unknown,
+}
+
+impl Environment {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Production => "production",
+            Self::Staging => "staging",
+            Self::Sandbox => "sandbox",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+impl Default for Environment {
+    fn default() -> Self {
+        Self::Production
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Service {
     pub id: String,
+    #[serde(default)]
+    pub environment: Environment,
     pub token: String,
     #[serde(default)]
     pub authorities: GlobPatternSet,
@@ -16,6 +45,13 @@ pub struct Service {
 impl Service {
     pub fn id(&self) -> &str {
         self.id.as_str()
+    }
+
+    // Allow dead code until we have the logic asking for the environment
+    // in the configuration retrieval subsystem.
+    #[allow(dead_code)]
+    pub fn environment(&self) -> &str {
+        self.environment.as_str()
     }
 
     pub fn token(&self) -> &str {


### PR DESCRIPTION
This adds an optional `environment` entry for `service`, defaulting to `production`. This can be changed to retrieve different configurations depending on whether the service is `production` or `staging`/`sandbox`.