### PR TITLE
Ignore chrono advisory till fix is released

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,2 @@
+[advisories]
+ignore = ["RUSTSEC-2020-0159"]

--- a/deny.toml
+++ b/deny.toml
@@ -49,7 +49,8 @@ notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    #"RUSTSEC-0000-0000",
+    # time/chrono problems, have not been a problem in practice, not much we can do at this moment.
+    "RUSTSEC-2020-0159"
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
There is a Rust vulnerability advisory for the chrono crate that we use in this plugin. Since this CVE has been around for a while and there is no fix in the short term. It's best to ignore it for now as at most it can cause a segfault. This PR adds a config option for `cargo audit` to ignore this particular advisory.