### PR TITLE
Get service token from fetched proxy config

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -350,7 +350,6 @@ to do useful work.
 ```yaml
 services:
   - id: "2555417834789"
-    token: service_token
     environment: production
     authorities:
       - "*.app"
@@ -363,8 +362,8 @@ services:
 Each element in the `services` array represents a `3scale` service. The fields are defined below:
 
 * `id`: Required. The `3scale` service identifier for this service.
-* `token`: Required. The `3scale` service token to be used to authenticate this service against
-           Apisonator. This token can be found in the proxy configuration for your service in Porta or can be retrieved from Porta with this command `curl https://<porta_host>/admin/api/services/<service_id>/proxy/configs/production/latest.json?access_token=<access_token>" | jq '.proxy_config.content.backend_authentication_value`.
+* `token`: Optional. The `3scale` service token to be used to authenticate this service against
+           Apisonator. This token can be found in the proxy configuration for your service in Porta or can be retrieved from Porta with this command `curl https://<porta_host>/admin/api/services/<service_id>/proxy/configs/production/latest.json?access_token=<access_token>" | jq '.proxy_config.content.backend_authentication_value`. It will be fetched automatically but can be provided for assurance purposes.
 * `environment`: Optional, defaults to `production`. The `3scale` environment of this service.
 * `authorities`: Required. An array of strings, each one representing the [`Authority`](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#Syntax)
                  of a `URL` to match. These strings do accept [`glob patterns`](https://en.wikipedia.org/wiki/Glob_%28programming%29)

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -132,7 +132,7 @@ mod test {
             }),
             services: Some(vec![Service {
                 id: "2555417834780".into(),
-                token: "service_token".into(),
+                token: Some("service_token".into()),
                 environment: Environment::Production,
                 authorities: GlobPatternSet::new(
                     [

--- a/src/proxy/authrep.rs
+++ b/src/proxy/authrep.rs
@@ -146,9 +146,14 @@ pub fn build_call(ar: &AuthRep) -> Result<Request, anyhow::Error> {
 
     let service = ar.service();
 
+    let service_token = if let Some(token) = service.token() {
+        token
+    } else {
+        anyhow::bail!("service token unavailable");
+    };
     let service = Service::new(
         service.id(),
-        threescalers::credentials::Credentials::ServiceToken(service.token().into()),
+        threescalers::credentials::Credentials::ServiceToken(service_token.into()),
     );
     let mut apicall = ApiCall::builder(&service);
     // the builder here can only fail if we fail to set a kind

--- a/src/proxy/http_context.rs
+++ b/src/proxy/http_context.rs
@@ -191,7 +191,13 @@ impl HttpAuthThreescale {
         self.add_http_request_header("x-3scale-upstream-url", upstream.url.as_str());
         self.add_http_request_header("x-3scale-timeout", &upstream.default_timeout().to_string());
         self.add_http_request_header("x-3scale-service-id", service.id());
-        self.add_http_request_header("x-3scale-service-token", service.token());
+        let service_token = if let Some(token) = service.token() {
+            token
+        } else {
+            // without service token, other info is useless.
+            anyhow::bail!("service token unavailable");
+        };
+        self.add_http_request_header("x-3scale-service-token", service_token);
         self.add_http_request_header("x-3scale-usages", &serde_json::to_string(&usages)?);
         Ok(())
     }

--- a/src/threescale/service.rs
+++ b/src/threescale/service.rs
@@ -35,7 +35,7 @@ pub struct Service {
     pub id: String,
     #[serde(default)]
     pub environment: Environment,
-    pub token: String,
+    pub token: Option<String>,
     #[serde(default)]
     pub authorities: GlobPatternSet,
     pub credentials: Credentials,
@@ -54,8 +54,8 @@ impl Service {
         self.environment
     }
 
-    pub fn token(&self) -> &str {
-        self.token.as_str()
+    pub fn token(&self) -> Option<&str> {
+        self.token.as_deref()
     }
 
     pub fn credentials(&self) -> &Credentials {


### PR DESCRIPTION
Making the service token optional in the configuration which will be taken from periodic fetch of proxy config from 3scale (porta?).

A point worth noting is that if service token is not fetched from some reason, it makes the plugin useable.