### PR TITLE
docs/reference: add destinationrule example for HTTPs to work

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -136,9 +136,9 @@ Once you are happy with the module configuration in `spec.config` and the rest o
 In order for the module to authorize requests against `3scale` it must have access to `3scale`
 services. This can be accomplished within `OpenShift Service Mesh` and `Istio` by applying
 an external [`ServiceEntry`](https://istio.io/v1.9/docs/reference/config/networking/service-entry/)
-object.
+object and a corresponding [`DestinationRule`](https://istio.io/v1.9/docs/reference/config/networking/destination-rule/) object for TLS configuration to use HTTPS protocol.
 
-The `custom resources` below just set up the `service entries` for access from within the mesh
+The `custom resources` below just set up the `service entries` and `destination rules` for secure access from within the mesh
 to the well-known [`SaaS`](https://en.wikipedia.org/wiki/Software_as_a_service) services from
 `3scale` for the [`Apisonator`](https://github.com/3scale/apisonator) (aka `backend`) and [`Porta`](https://github.com/3scale/porta)
 (aka `system`) components offering respectively the `Service Management API` and the
@@ -174,6 +174,27 @@ spec:
   location: MESH_EXTERNAL
   resolution: DNS
 ---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: threescale-saas-backend
+spec:
+  host: su1.3scale.net
+  trafficPolicy:
+    tls:
+      mode: SIMPLE
+      sni: su1.3scale.net
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: threescale-saas-system
+spec:
+  host: multitenant.3scale.net
+  trafficPolicy:
+    tls:
+      mode: SIMPLE
+      sni: multitenant.3scale.net
 ```
 
 Just like any `YAML` `custom resource` file, these objects can be applied in your cluster via
@@ -182,7 +203,7 @@ the `oc apply` command.
 **Note**: Technically there is nothing preventing you from deploying an in-mesh `3scale` service.
           If so, then you'll want to change the `location` of these services in the resources
           above. Check the `ServiceEntry` [`documentation`](https://istio.io/v1.9/docs/reference/config/networking/service-entry/)
-          for more details.
+          and `DestinationRule` [`documentation`](https://istio.io/v1.9/docs/reference/config/networking/destination-rule/) for more details.
 
 ## Module configuration
 

--- a/src/proxy/root_context.rs
+++ b/src/proxy/root_context.rs
@@ -131,7 +131,7 @@ impl Context for RootAuthThreescale {
                 let mut rules_updated: bool = false;
 
                 let config = self.configuration.as_mut().map(|config| config.get_mut());
-                let services_op = config.map(|config| config.services.as_mut()).flatten();
+                let services_op = config.and_then(|config| config.services.as_mut());
                 let services = services_op.unwrap(); // cannot make a callout without services
 
                 if let Some(service) = services.iter_mut().find(|sv| sv.id() == cf.service_id()) {
@@ -364,7 +364,7 @@ impl RootAuthThreescale {
     }
 
     pub fn get_system_config(&self) -> Option<&crate::threescale::System> {
-        self.get_configuration().map(|conf| conf.system()).flatten()
+        self.get_configuration().and_then(|conf| conf.system())
     }
 
     fn get_next_tick(&self) -> Option<(Duration, Duration)> {


### PR DESCRIPTION
Connecting to backends over HTTPS will fail if `DestinationRule` is not provided. This PR updates the docs to make them consistent with the example used.