### PR TITLE
Better response codes and destination rule example

### DIFF
--- a/servicemesh/Makefile
+++ b/servicemesh/Makefile
@@ -28,22 +28,30 @@ svcentry-apply:
 svcentry-clean:
 	$(KUBECTL) -n $(BOOKINFO_NS) delete -f $(PROJECT_PATH)/crds/threescale-saas-svcentry.yaml
 
+.PHONY: dstrule-apply
+dstrule-apply:
+	$(KUBECTL) -n $(BOOKINFO_NS) apply -f $(PROJECT_PATH)/crds/threescale-saas-dstrule.yaml
+
+.PHONY: dstrule-clean
+svcentry-clean:
+	$(KUBECTL) -n $(BOOKINFO_NS) delete -f $(PROJECT_PATH)/crds/threescale-saas-dstrule.yaml
+
 .PHONY: istio-apply
-istio-apply: svcentry-apply
+istio-apply: svcentry-apply dstrule-apply
 	$(KUBECTL) -n $(BOOKINFO_NS) apply -f $(PROJECT_PATH)/crds/istio/
 
 .PHONY: istio-clean
-istio-clean: svcentry-clean
+istio-clean: svcentry-clean dstrule-clean
 	$(KUBECTL) -n $(BOOKINFO_NS) delete -f $(PROJECT_PATH)/crds/istio/
 
 .PHONY: ossm-apply
 ossm-clean: export KUBECTL?=oc
-ossm-apply: svcentry-apply
+ossm-apply: svcentry-apply dstrule-apply
 	$(KUBECTL) -n $(BOOKINFO_NS) apply -f $(PROJECT_PATH)/crds/ossm/
 
 .PHONY: ossm-clean
 ossm-clean: export KUBECTL?=oc
-ossm-clean: svcentry-clean
+ossm-clean: svcentry-clean dstrule-apply
 	$(KUBECTL) -n $(BOOKINFO_NS) delete -f $(PROJECT_PATH)/crds/ossm/
 
 .PHONY: istio-loglevel

--- a/servicemesh/crds/threescale-saas-dstrule.yaml
+++ b/servicemesh/crds/threescale-saas-dstrule.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: threescale-saas-backend
+spec:
+  host: su1.3scale.net
+  trafficPolicy:
+    tls:
+      mode: SIMPLE
+      sni: su1.3scale.net
+---
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: threescale-saas-system
+spec:
+  host: multitenant.3scale.net
+  trafficPolicy:
+    tls:
+      mode: SIMPLE
+      sni: multitenant.3scale.net
+---

--- a/src/proxy/http_context.rs
+++ b/src/proxy/http_context.rs
@@ -141,16 +141,23 @@ impl Context for HttpAuthThreescale {
         let status_code = match self
             .get_http_call_response_headers()
             .into_iter()
-            .find(|(key, _)| key.as_str() == ":status") {
-                None => {
-                    debug!(self, "on_http_call_response: empty status header {}", token_id);
-                    self.send_http_response(502, vec![], Some(b"Bad Gateway\n"));
-                    return;
-                }
-                Some((_, code)) => code.parse::<u32>().unwrap_or(500),
-            };
+            .find(|(key, _)| key.as_str() == ":status")
+        {
+            None => {
+                debug!(
+                    self,
+                    "on_http_call_response: empty status header {}", token_id
+                );
+                self.send_http_response(502, vec![], Some(b"Bad Gateway\n"));
+                return;
+            }
+            Some((_, code)) => code.parse::<u32>().unwrap_or(500),
+        };
 
-        info!(self, "on_http_call_response: received {} response {}", status_code, token_id);
+        info!(
+            self,
+            "on_http_call_response: received {} response {}", status_code, token_id
+        );
         if status_code == 200 {
             info!(self, "on_http_call_response: authorized {}", token_id);
             self.resume_http_request();


### PR DESCRIPTION
This PR:
- Fixes #79 by replying with response codes from 3scale if it's not 200 OK.
- Adds `DestinationRule` crd examples for HTTPS to work.