### PR TITLE
Let configuration fetch on start and not after 30 sec

### DIFF
--- a/src/proxy/root_context.rs
+++ b/src/proxy/root_context.rs
@@ -299,7 +299,7 @@ impl RootContext for RootAuthThreescale {
         // cancel any previous work updating configurations
         Fetcher::clear();
 
-        let _ = self.set_next_tick();
+        self.on_tick();
 
         true
     }


### PR DESCRIPTION
It was needlessly postponed to the next tick. 