### PR TITLE
Make extension return same status codes as APIcast

### DIFF
--- a/src/proxy/authrep.rs
+++ b/src/proxy/authrep.rs
@@ -142,7 +142,9 @@ pub fn build_call(ar: &AuthRep) -> Result<Request, anyhow::Error> {
     let usage = Usage::new(usage.as_slice());
     let txn = Transaction::new(app, None, Some(&usage), None);
     let txns = vec![txn];
-    let extensions = extensions::List::new().no_body();
+    let extensions = extensions::List::new()
+        .no_body()
+        .push_other("rejection_reason_header".into(), "1".into());
 
     let service = ar.service();
 


### PR DESCRIPTION
APIcast has simple return codes 403 if using the wrong auth or missing and 429 if limits are exceeded. Currently, the extension returns whatever the backend returns, which is different. The goal of this PR is to unify the behaviour.

Example backend return codes:
Missing user_key -> 403
Wrong app_key -> 409
Wrong app_id and app_key -> 403
Limits exceeded -> 409! 

Based on return codes, we cannot know why the backend rejected the request and filter out only limits exceeded rejections. To do this, we need to use the `rejection_reason_header` extension, which has its own problem of not being applied everywhere and only sending the header if the limits are exceeded, not if the auth is missing, which is the reason why this PR is not as elegant as I would like.