### PR TITLE
Make mapping rules optional

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -369,19 +369,7 @@ mod test {
                         }
                       }
                     ]
-                  },
-                  "mapping_rules": [
-                    {
-                      "method": "ANY",
-                      "pattern": "/",
-                      "usages": [
-                        {
-                          "name": "Hits",
-                          "delta": 1
-                        }
-                      ]
-                    }
-                  ]
+                  }
                 }
               ],
               "passthrough_metadata": true

--- a/src/threescale/service.rs
+++ b/src/threescale/service.rs
@@ -39,6 +39,7 @@ pub struct Service {
     #[serde(default)]
     pub authorities: GlobPatternSet,
     pub credentials: Credentials,
+    #[serde(default)]
     pub mapping_rules: Vec<MappingRule>,
 }
 


### PR DESCRIPTION
Currently, you have to specify mapping rules for service even if they should be an empty list, this PR changes it to implicitly be an empty list.