### PR TITLE
Migrate from using 3scale rust-url fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,9 +25,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
@@ -70,9 +70,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdbc37d37da9e5bce8173f3a41b71d9bf3c674deebbaceacd0ebdabde76efb03"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
  "android-tzdata",
  "num-traits",
@@ -96,14 +96,23 @@ version = "1.0.1"
 source = "git+https://github.com/3scale-rs/rust-url?branch=3scale#78803c179d1eeffad5a9a90d2fe20c739f3dec8f"
 dependencies = [
  "matches",
- "percent-encoding",
+ "percent-encoding 2.1.0",
+]
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+dependencies = [
+ "percent-encoding 2.3.0",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
@@ -147,6 +156,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,15 +201,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "log"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "518ef76f2f87365916b142844c16d8fefd85039bc5699050210a7778ee1cd1de"
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "matches"
@@ -221,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9670a07f94779e00908f3e686eab508878ebb390ba6e604d3a284c00e8d0487b"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "percent-encoding"
@@ -231,10 +250,16 @@ version = "2.1.0"
 source = "git+https://github.com/3scale-rs/rust-url?branch=3scale#78803c179d1eeffad5a9a90d2fe20c739f3dec8f"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.59"
+name = "percent-encoding"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
@@ -359,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
+checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -382,9 +407,9 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "serde"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
@@ -403,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.163"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -451,7 +476,7 @@ dependencies = [
  "serde",
  "serde_json",
  "straitjacket_macro",
- "url",
+ "url 2.2.2",
 ]
 
 [[package]]
@@ -530,7 +555,7 @@ dependencies = [
  "straitjacket",
  "thiserror",
  "threescalers",
- "url",
+ "url 2.4.0",
 ]
 
 [[package]]
@@ -543,7 +568,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "no-std-compat",
- "percent-encoding",
+ "percent-encoding 2.3.0",
  "regex",
  "serde",
  "serde-xml-rs",
@@ -593,13 +618,13 @@ checksum = "1865806a559042e51ab5414598446a5871b561d21b6764f2eabb0dd481d880a6"
 
 [[package]]
 name = "url"
-version = "2.2.2"
-source = "git+https://github.com/3scale-rs/rust-url?branch=3scale#78803c179d1eeffad5a9a90d2fe20c739f3dec8f"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
- "form_urlencoded",
- "idna",
- "matches",
- "percent-encoding",
+ "form_urlencoded 1.2.0",
+ "idna 0.4.0",
+ "percent-encoding 2.3.0",
  "serde",
 ]
 
@@ -639,6 +664,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.13"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d8f380ae16a37b30e6a2cf67040608071384b1450c189e61bea3ff57cde922d"
+checksum = "52839dc911083a8ef63efa4d039d1f58b5e409f923e44c80828f206f66e5541c"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,20 +92,11 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
-source = "git+https://github.com/3scale-rs/rust-url?branch=3scale#78803c179d1eeffad5a9a90d2fe20c739f3dec8f"
-dependencies = [
- "matches",
- "percent-encoding 2.1.0",
-]
-
-[[package]]
-name = "form_urlencoded"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
- "percent-encoding 2.3.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -143,16 +134,6 @@ dependencies = [
  "bytes",
  "fnv",
  "itoa",
-]
-
-[[package]]
-name = "idna"
-version = "0.2.3"
-source = "git+https://github.com/3scale-rs/rust-url?branch=3scale#78803c179d1eeffad5a9a90d2fe20c739f3dec8f"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
 ]
 
 [[package]]
@@ -212,12 +193,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
-name = "matches"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,11 +218,6 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
-
-[[package]]
-name = "percent-encoding"
-version = "2.1.0"
-source = "git+https://github.com/3scale-rs/rust-url?branch=3scale#78803c179d1eeffad5a9a90d2fe20c739f3dec8f"
 
 [[package]]
 name = "percent-encoding"
@@ -469,20 +439,20 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "straitjacket"
-version = "0.1.0"
-source = "git+https://github.com/3scale-rs/straitjacket?branch=master#51c60657e6deeeb98b30a61cf5d59f230946357d"
+version = "0.2.0"
+source = "git+https://github.com/3scale-rs/straitjacket?tag=v0.2.0#e92049a164f5cef4efb72640657409240ee9ea95"
 dependencies = [
  "http",
  "serde",
  "serde_json",
  "straitjacket_macro",
- "url 2.2.2",
+ "url",
 ]
 
 [[package]]
 name = "straitjacket_macro"
-version = "0.1.0"
-source = "git+https://github.com/3scale-rs/straitjacket_macro?branch=master#f707838291dd5a4e044b03d9af50b0ee6c6a0e01"
+version = "0.2.0"
+source = "git+https://github.com/3scale-rs/straitjacket_macro?tag=v0.2.0#5e1a7840eaf8205ffb4cebc556e61f9af62c40f5"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -555,7 +525,7 @@ dependencies = [
  "straitjacket",
  "thiserror",
  "threescalers",
- "url 2.4.0",
+ "url",
 ]
 
 [[package]]
@@ -568,7 +538,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "no-std-compat",
- "percent-encoding 2.3.0",
+ "percent-encoding",
  "regex",
  "serde",
  "serde-xml-rs",
@@ -622,9 +592,9 @@ version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
- "form_urlencoded 1.2.0",
- "idna 0.4.0",
- "percent-encoding 2.3.0",
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,6 @@ prng_pcg32 = ["rand_pcg"]
 prng_xoshiro128 = ["rand_xoshiro"]
 prng_xorshift = ["rand_xorshift"]
 
-[patch.crates-io]
-url = { git = "https://github.com/3scale-rs/rust-url", branch = "3scale" }
-percent-encoding = { git = "https://github.com/3scale-rs/rust-url", branch = "3scale" }
-
 [dependencies]
 proxy-wasm = { git = "https://github.com/3scale/proxy-wasm-rust-sdk", branch = "3scale" }
 log = "^0.4"
@@ -42,7 +38,7 @@ threescalers = { version = "^0.8", features = ["std", "xml-response", "rest-mapp
 straitjacket = { git = "https://github.com/3scale-rs/straitjacket", branch = "master" }
 anyhow = "^1"
 thiserror = "^1"
-url = { git = "https://github.com/3scale-rs/rust-url", branch = "3scale", features = ["serde"] }
+url = { version = "^2.4", features = ["serde"] }
 regex = { version = "^1", default-features = false, features = ["std", "perf"] }
 base64 = "^0.21"
 prost = { version = "^0.11", features = ["prost-derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ proxy-wasm = { git = "https://github.com/3scale/proxy-wasm-rust-sdk", branch = "
 log = "^0.4"
 serde = { version = "^1", features = ["derive"] }
 threescalers = { version = "^0.8", features = ["std", "xml-response", "rest-mappings", "rest-mappings-serde"]}
-straitjacket = { git = "https://github.com/3scale-rs/straitjacket", branch = "master" }
+straitjacket = { git = "https://github.com/3scale-rs/straitjacket", tag = "v0.2.0" }
 anyhow = "^1"
 thiserror = "^1"
 url = { version = "^2.4", features = ["serde"] }


### PR DESCRIPTION
Thanks to merging https://github.com/servo/rust-url/pull/674, we can migrate to using the official package. Sadly, there is no release containing the fix yet, but I will migrate this PR after it is released.

Part of this is also switching to a tagged version of straitjacket. I did not do two PRs because of two updates to cargo.lock