### PR TITLE
Remove stable clippy

### DIFF
--- a/.github/workflows/clippy.yaml
+++ b/.github/workflows/clippy.yaml
@@ -16,9 +16,9 @@ jobs:
       fail-fast: false
       matrix:
         rust:
-          - stable
+          - 1.69
           # Help identify breakages about to land in stable earlier
-          - beta
+          - stable
 
     steps:
       - uses: actions/checkout@v2

--- a/bors.toml
+++ b/bors.toml
@@ -1,5 +1,5 @@
-status = ["ci (stable, false, --all-features)", "ci (beta, false, --all-features)", "ci (1.54.0, false, --all-features)", "clippy_check (stable)", "rustfmt", "audit_check", "licensing (bans licenses sources)"]
-pr_status = ["ci (stable, false, --all-features)", "ci (beta, false, --all-features)", "ci (1.54.0, false, --all-features)", "clippy_check (stable)", "rustfmt", "audit_check", "licensing (bans licenses sources)"]
+status = ["ci (stable, false, --all-features)", "ci (beta, false, --all-features)", "ci (1.54.0, false, --all-features)", "clippy_check (1.69)", "rustfmt", "audit_check", "licensing (bans licenses sources)"]
+pr_status = ["ci (stable, false, --all-features)", "ci (beta, false, --all-features)", "ci (1.54.0, false, --all-features)", "clippy_check (1.69)", "rustfmt", "audit_check", "licensing (bans licenses sources)"]
 timeout_sec = 1800
 use_squash_merge = false
 block_labels = ["wip"]

--- a/src/configuration/operation/string.rs
+++ b/src/configuration/operation/string.rs
@@ -109,7 +109,7 @@ impl StringOp {
                 stack.push(input);
             }
             Self::Reverse => {
-                let value = input.chars().into_iter().rev().collect::<Cow<str>>();
+                let value = input.chars().rev().collect::<Cow<str>>();
                 stack.push(value);
             }
             Self::Split { separator, max } => {


### PR DESCRIPTION
We freeze everything, including the rust version, I do not see a reason why we should reject PRs based on new checks that weren't applicable at the time of writing.

Also, fix the error for 1.69 rust