### PR TITLE
Allow cache configuration

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -77,6 +77,7 @@ mod test {
     use core::time::Duration;
     use std::convert::TryInto;
 
+    use crate::configuration::api::v1::Cache;
     use threescalers::http::mapping_rule::{Method, RestRule};
 
     use crate::threescale::{
@@ -120,6 +121,10 @@ mod test {
                 },
                 token: "atoken".into(),
                 ttl: Some(300),
+            }),
+            cache: Some(Cache {
+                ttl: Some(10),
+                jitter: Some(15),
             }),
             backend: Some(Backend {
                 name: Some("backend-name".into()),
@@ -282,6 +287,10 @@ mod test {
                   "timeout": 5000
                 },
                 "token": "atoken"
+              },
+              "cache": {
+                "ttl": 10,
+                "jitter": 15
               },
               "backend": {
                 "name": "backend-name",

--- a/src/configuration/api/v1.rs
+++ b/src/configuration/api/v1.rs
@@ -4,11 +4,18 @@ use crate::configuration::MissingError;
 use crate::threescale::{Backend, Service, System};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Cache {
+    pub ttl: Option<u64>,
+    pub jitter: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename = "3scale")]
 pub struct Configuration {
     pub system: Option<System>,
     pub backend: Option<Backend>,
     pub services: Option<Vec<Service>>,
+    pub cache: Option<Cache>,
     // pass request to the next filter in the chain
     pub passthrough_metadata: Option<bool>,
 }


### PR DESCRIPTION
# Changes

- Currently, you can configure ttl and jitter
- Add Cache configuration
  - The API version did not change. Is that correct?
  - Currently, it is a top-level property. Should it be moved to services or the system section as it proxy config cache?

# TODO:

- [ ] Test this properly
